### PR TITLE
health: Implement multistream status integrated with stream status

### DIFF
--- a/health/core.go
+++ b/health/core.go
@@ -128,10 +128,10 @@ func (c *Core) handleSingleEvent(evt data.Event) {
 	}
 }
 
-func (c *Core) GetStatus(manifestID string) (Status, error) {
+func (c *Core) GetStatus(manifestID string) (*Status, error) {
 	record, ok := c.storage.Get(manifestID)
 	if !ok {
-		return Status{}, ErrStreamNotFound
+		return nil, ErrStreamNotFound
 	}
 	return record.LastStatus, nil
 }

--- a/health/record.go
+++ b/health/record.go
@@ -21,7 +21,7 @@ type Record struct {
 	EventSubs  []chan<- data.Event
 
 	ReducersState map[int]interface{}
-	LastStatus    Status
+	LastStatus    *Status
 }
 
 func NewRecord(id string, conditions []ConditionType) *Record {
@@ -31,7 +31,7 @@ func NewRecord(id string, conditions []ConditionType) *Record {
 		disposed:      make(chan struct{}),
 		EventsByID:    map[uuid.UUID]data.Event{},
 		ReducersState: map[int]interface{}{},
-		LastStatus: Status{
+		LastStatus: &Status{
 			ID:         id,
 			Healthy:    *NewCondition("", time.Time{}, nil, nil, nil),
 			Conditions: make([]*Condition, len(conditions)),

--- a/health/reducer.go
+++ b/health/reducer.go
@@ -8,13 +8,13 @@ import (
 type Reducer interface {
 	Bindings() []event.BindingArgs
 	Conditions() []ConditionType
-	Reduce(current Status, state interface{}, evt data.Event) (Status, interface{})
+	Reduce(current *Status, state interface{}, evt data.Event) (*Status, interface{})
 }
 
-type ReducerFunc func(Status, interface{}, data.Event) (Status, interface{})
+type ReducerFunc func(*Status, interface{}, data.Event) (*Status, interface{})
 
 func (f ReducerFunc) Bindings() []event.BindingArgs { return nil }
 func (f ReducerFunc) Conditions() []ConditionType   { return nil }
-func (f ReducerFunc) Reduce(current Status, state interface{}, evt data.Event) (Status, interface{}) {
+func (f ReducerFunc) Reduce(current *Status, state interface{}, evt data.Event) (*Status, interface{}) {
 	return f(current, state, evt)
 }

--- a/health/reducers/health.go
+++ b/health/reducers/health.go
@@ -20,6 +20,13 @@ func reduceHealth(current health.Status, _ interface{}, evt data.Event) (health.
 		}
 	}
 	isHealthy := healthyMustsCount == len(healthyMustHaves)
+	for _, ms := range current.Multistream {
+		for _, cond := range ms.Conditions {
+			if cond.Type == ConditionMultistreamConnected && cond.Status != nil && !*cond.Status {
+				isHealthy = false
+			}
+		}
+	}
 	healthyCond := health.NewCondition("", evt.Timestamp(), &isHealthy, nil, &current.Healthy)
 
 	return health.Status{

--- a/health/reducers/health.go
+++ b/health/reducers/health.go
@@ -12,7 +12,7 @@ var healthyMustHaves = map[health.ConditionType]bool{
 
 var HealthReducer = health.ReducerFunc(reduceHealth)
 
-func reduceHealth(current health.Status, _ interface{}, evt data.Event) (health.Status, interface{}) {
+func reduceHealth(current *health.Status, _ interface{}, evt data.Event) (*health.Status, interface{}) {
 	healthyMustsCount := 0
 	for _, cond := range current.Conditions {
 		if healthyMustHaves[cond.Type] && cond.Status != nil && *cond.Status {
@@ -29,7 +29,7 @@ func reduceHealth(current health.Status, _ interface{}, evt data.Event) (health.
 	}
 	healthyCond := health.NewCondition("", evt.Timestamp(), &isHealthy, nil, &current.Healthy)
 
-	return health.Status{
+	return &health.Status{
 		ID:         current.ID,
 		Healthy:    *healthyCond,
 		Conditions: current.Conditions,

--- a/health/reducers/multistream.go
+++ b/health/reducers/multistream.go
@@ -29,7 +29,7 @@ func (t MultistreamReducer) Conditions() []health.ConditionType {
 	return nil
 }
 
-func (t MultistreamReducer) Reduce(current health.Status, _ interface{}, evtIface data.Event) (health.Status, interface{}) {
+func (t MultistreamReducer) Reduce(current *health.Status, _ interface{}, evtIface data.Event) (*health.Status, interface{}) {
 	evt, ok := evtIface.(*data.WebhookEvent)
 	if !ok {
 		return current, nil
@@ -54,7 +54,7 @@ func (t MultistreamReducer) Reduce(current health.Status, _ interface{}, evtIfac
 		}
 	}
 
-	return health.Status{
+	return &health.Status{
 		ID:          current.ID,
 		Healthy:     current.Healthy,
 		Conditions:  current.Conditions,

--- a/health/reducers/multistream.go
+++ b/health/reducers/multistream.go
@@ -1,0 +1,114 @@
+package reducers
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/livepeer/livepeer-data/health"
+	"github.com/livepeer/livepeer-data/pkg/data"
+	"github.com/livepeer/livepeer-data/pkg/event"
+)
+
+const (
+	ConditionMultistreamConnected health.ConditionType = "Connected"
+
+	webhooksExchange      = "webhooks_default_exchange"
+	multistreamBindingKey = "events.multistream.#"
+)
+
+type MultistreamReducer struct{}
+
+func (t MultistreamReducer) Bindings() []event.BindingArgs {
+	return []event.BindingArgs{{Exchange: webhooksExchange, Key: multistreamBindingKey}}
+}
+
+func (t MultistreamReducer) Conditions() []health.ConditionType {
+	// We hold separate conditions under the multistream root field in status obj.
+	return nil
+}
+
+func (t MultistreamReducer) Reduce(current health.Status, _ interface{}, evtIface data.Event) (health.Status, interface{}) {
+	evt, ok := evtIface.(*data.WebhookEvent)
+	if !ok {
+		return current, nil
+	}
+	if !strings.HasPrefix(evt.Event, "multistream.") {
+		return current, nil
+	}
+
+	ts := evt.Timestamp()
+	var payload data.MultistreamWebhookPayload
+	if err := json.Unmarshal(evt.Payload, &payload); err != nil {
+		glog.Errorf("Error parsing multistream webhook payload. err=%q", err)
+		return current, nil
+	}
+	target := payload.Target
+
+	multistream, idx := cloneAppendMultistreamStatus(current.Multistream, target)
+	conditions := multistream[idx].Conditions
+	for i, cond := range conditions {
+		if status := multistreamConditionStatus(evt, cond.Type); status != nil {
+			conditions[i] = health.NewCondition(cond.Type, ts, status, nil, cond)
+		}
+	}
+
+	return health.Status{
+		ID:          current.ID,
+		Healthy:     current.Healthy,
+		Conditions:  current.Conditions,
+		Multistream: multistream,
+	}, nil
+}
+
+var connectedCondByEvent = map[string]bool{
+	"multistream.connected":    true,
+	"multistream.disconnected": false,
+	"multistream.error":        false,
+}
+
+func multistreamConditionStatus(evt *data.WebhookEvent, condType health.ConditionType) *bool {
+	switch condType {
+	case ConditionMultistreamConnected:
+		connected, ok := connectedCondByEvent[evt.Event]
+		if !ok {
+			glog.Errorf("Unknown multistream webhook event. event=%q", evt.Event)
+			return nil
+		}
+		return &connected
+	default:
+		glog.Errorf("Unknown multistream status condition. conditionType=%q", condType)
+		return nil
+	}
+}
+
+func cloneAppendMultistreamStatus(current []*health.MultistreamStatus, target data.MultistreamTargetInfo) ([]*health.MultistreamStatus, int) {
+	multistream := make([]*health.MultistreamStatus, len(current))
+	copy(multistream, current)
+	for idx, ms := range multistream {
+		if targetsEq(ms.Target, target) {
+			multistream[idx] = cloneMultistreamStatus(ms)
+			return multistream, idx
+		}
+	}
+
+	multistream = append(multistream, &health.MultistreamStatus{
+		Target: target,
+		Conditions: []*health.Condition{
+			health.NewCondition(ConditionMultistreamConnected, time.Time{}, nil, nil, nil),
+		},
+	})
+	return multistream, len(multistream) - 1
+}
+
+func cloneMultistreamStatus(status *health.MultistreamStatus) *health.MultistreamStatus {
+	clone := *status
+	clone.Conditions = make([]*health.Condition, len(status.Conditions))
+	copy(clone.Conditions, status.Conditions)
+	return &clone
+}
+
+func targetsEq(t1, t2 data.MultistreamTargetInfo) bool {
+	return t1.Profile == t2.Profile && t1.ID == t2.ID
+}

--- a/health/reducers/pipeline.go
+++ b/health/reducers/pipeline.go
@@ -14,6 +14,7 @@ var (
 func DefaultPipeline(golpExchange string, shardPrefixes []string) (reducers []health.Reducer, starTimeOffset time.Duration) {
 	return []health.Reducer{
 		TranscodeReducer{golpExchange, shardPrefixes},
+		MultistreamReducer{},
 		HealthReducer,
 		StatsReducer(statsWindows),
 	}, maxStatsWindow

--- a/health/reducers/stats.go
+++ b/health/reducers/stats.go
@@ -14,7 +14,7 @@ type statsAggrs struct {
 }
 
 func StatsReducer(statsWindows []time.Duration) health.ReducerFunc {
-	return func(current health.Status, stateIface interface{}, evt data.Event) (health.Status, interface{}) {
+	return func(current *health.Status, stateIface interface{}, evt data.Event) (*health.Status, interface{}) {
 		var state *statsAggrs
 		if stateIface != nil {
 			state = stateIface.(*statsAggrs)
@@ -35,7 +35,7 @@ func StatsReducer(statsWindows []time.Duration) health.ReducerFunc {
 			}
 			conditions[i] = reduceCondStats(cond, ts, statsAggr, statsWindows)
 		}
-		return health.Status{
+		return &health.Status{
 			ID:         current.ID,
 			Healthy:    *reduceCondStats(&current.Healthy, ts, state.HealthStats, statsWindows),
 			Conditions: conditions,

--- a/health/reducers/transcode.go
+++ b/health/reducers/transcode.go
@@ -44,7 +44,7 @@ func (t TranscodeReducer) Conditions() []health.ConditionType {
 	return transcodeConditions
 }
 
-func (t TranscodeReducer) Reduce(current health.Status, _ interface{}, evtIface data.Event) (health.Status, interface{}) {
+func (t TranscodeReducer) Reduce(current *health.Status, _ interface{}, evtIface data.Event) (*health.Status, interface{}) {
 	evt, ok := evtIface.(*data.TranscodeEvent)
 	if !ok {
 		return current, nil
@@ -59,7 +59,7 @@ func (t TranscodeReducer) Reduce(current health.Status, _ interface{}, evtIface 
 		}
 	}
 
-	return health.Status{
+	return &health.Status{
 		ID:         current.ID,
 		Healthy:    current.Healthy,
 		Conditions: conditions,

--- a/health/reducers/transcode.go
+++ b/health/reducers/transcode.go
@@ -52,13 +52,11 @@ func (t TranscodeReducer) Reduce(current health.Status, _ interface{}, evtIface 
 
 	ts := evt.Timestamp()
 	conditions := make([]*health.Condition, len(current.Conditions))
-	for i, cond := range current.Conditions {
-		status := conditionStatus(evt, cond.Type)
-		if status == nil {
-			conditions[i] = cond
-			continue
+	copy(conditions, current.Conditions)
+	for i, cond := range conditions {
+		if status := conditionStatus(evt, cond.Type); status != nil {
+			conditions[i] = health.NewCondition(cond.Type, ts, status, nil, cond)
 		}
-		conditions[i] = health.NewCondition(cond.Type, ts, status, nil, cond)
 	}
 
 	return health.Status{

--- a/health/status.go
+++ b/health/status.go
@@ -3,13 +3,20 @@ package health
 import (
 	"time"
 
+	"github.com/livepeer/livepeer-data/pkg/data"
 	"github.com/livepeer/livepeer-data/stats"
 )
 
 type Status struct {
-	ID         string       `json:"id"`
-	Healthy    Condition    `json:"healthy"`
-	Conditions []*Condition `json:"conditions"`
+	ID          string               `json:"id"`
+	Healthy     Condition            `json:"healthy"`
+	Conditions  []*Condition         `json:"conditions"`
+	Multistream []*MultistreamStatus `json:"multistream,omitempty"`
+}
+
+type MultistreamStatus struct {
+	Target     data.MultistreamTargetInfo
+	Conditions []*Condition
 }
 
 func (s Status) GetCondition(condType ConditionType) *Condition {

--- a/pkg/data/event.go
+++ b/pkg/data/event.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 )
 
+// TODO: Call these just Message for consistency with livepeer-com
 type Event interface {
 	ID() uuid.UUID
 	Timestamp() time.Time
@@ -15,10 +16,10 @@ type Event interface {
 type EventType string
 
 type Base struct {
-	Type        EventType    `json:"type"`
-	ID_         uuid.UUID    `json:"id"`
-	Timestamp_  UnixNanoTime `json:"timestamp"`
-	ManifestID_ string       `json:"manifestId"`
+	Type        EventType      `json:"type"`
+	ID_         uuid.UUID      `json:"id"`
+	Timestamp_  UnixMillisTime `json:"timestamp"`
+	ManifestID_ string         `json:"manifestId"`
 }
 
 var _ Event = (*Base)(nil)
@@ -27,7 +28,7 @@ func newEventBase(type_ EventType, mid string) Base {
 	return Base{
 		Type:        type_,
 		ID_:         uuid.New(),
-		Timestamp_:  UnixNanoTime{time.Now().UTC()},
+		Timestamp_:  UnixMillisTime{time.Now().UTC()},
 		ManifestID_: mid,
 	}
 }

--- a/pkg/data/time.go
+++ b/pkg/data/time.go
@@ -5,17 +5,23 @@ import (
 	"time"
 )
 
-type UnixNanoTime struct{ time.Time }
+const nanosInMillis = int64(time.Millisecond / time.Nanosecond)
 
-func (u UnixNanoTime) MarshalJSON() ([]byte, error) {
-	return json.Marshal(u.UnixNano())
+type UnixMillisTime struct{ time.Time }
+
+func (u UnixMillisTime) UnixMillis() int64 {
+	return u.UnixNano() / nanosInMillis
 }
 
-func (u *UnixNanoTime) UnmarshalJSON(data []byte) error {
-	var unixNano int64
-	if err := json.Unmarshal(data, &unixNano); err != nil {
+func (u UnixMillisTime) MarshalJSON() ([]byte, error) {
+	return json.Marshal(u.UnixMillis())
+}
+
+func (u *UnixMillisTime) UnmarshalJSON(data []byte) error {
+	var unixMillis int64
+	if err := json.Unmarshal(data, &unixMillis); err != nil {
 		return err
 	}
-	u.Time = time.Unix(0, unixNano).UTC()
+	u.Time = time.Unix(0, unixMillis*nanosInMillis).UTC()
 	return nil
 }

--- a/pkg/data/transcode.go
+++ b/pkg/data/transcode.go
@@ -12,7 +12,7 @@ func NewTranscodeEvent(nodeID, mid string, seg SegmentMetadata, startTime time.T
 		Base:      base,
 		NodeID:    nodeID,
 		Segment:   seg,
-		StartTime: UnixNanoTime{startTime},
+		StartTime: UnixMillisTime{startTime},
 		LatencyMs: base.Timestamp_.Sub(startTime).Milliseconds(),
 		Success:   success,
 		Attempts:  attempts,
@@ -23,7 +23,7 @@ type TranscodeEvent struct {
 	Base
 	NodeID    string                 `json:"nodeId"`
 	Segment   SegmentMetadata        `json:"segment"`
-	StartTime UnixNanoTime           `json:"startTime"`
+	StartTime UnixMillisTime         `json:"startTime"`
 	LatencyMs int64                  `json:"latencyMs"`
 	Success   bool                   `json:"success"`
 	Attempts  []TranscodeAttemptInfo `json:"attempts"`

--- a/pkg/data/webhook.go
+++ b/pkg/data/webhook.go
@@ -8,9 +8,13 @@ import (
 const EventTypeWebhook EventType = "webhook_event"
 
 func NewWebhookEvent(mid, event, userID, streamID, sessionID string, payload interface{}) (*WebhookEvent, error) {
-	rawPayload, err := json.Marshal(payload)
-	if err != nil {
-		return nil, fmt.Errorf("error marshalling webhook event payload: %w", err)
+	var rawPayload []byte
+	var err error
+	if payload != nil {
+		rawPayload, err = json.Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("error marshalling webhook event payload: %w", err)
+		}
 	}
 	return &WebhookEvent{
 		Base:      newEventBase(EventTypeWebhook, mid),

--- a/pkg/data/webhook.go
+++ b/pkg/data/webhook.go
@@ -1,0 +1,32 @@
+package data
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const EventTypeWebhook EventType = "webhook_event"
+
+func NewWebhookEvent(mid, event, userID, streamID, sessionID string, payload interface{}) (*WebhookEvent, error) {
+	rawPayload, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling webhook event payload: %w", err)
+	}
+	return &WebhookEvent{
+		Base:      newEventBase(EventTypeWebhook, mid),
+		Event:     event,
+		UserID:    userID,
+		StreamID:  streamID,
+		SessionID: sessionID,
+		Payload:   rawPayload,
+	}, nil
+}
+
+type WebhookEvent struct {
+	Base
+	Event     string          `json:"event"`
+	UserID    string          `json:"userId"`
+	StreamID  string          `json:"streamId"`
+	SessionID string          `json:"sessionId,omitempty"`
+	Payload   json.RawMessage `json:"payload,omitempty"`
+}

--- a/pkg/data/webhook.go
+++ b/pkg/data/webhook.go
@@ -30,3 +30,13 @@ type WebhookEvent struct {
 	SessionID string          `json:"sessionId,omitempty"`
 	Payload   json.RawMessage `json:"payload,omitempty"`
 }
+
+type MultistreamWebhookPayload struct {
+	Target MultistreamTargetInfo `json:"target"`
+}
+
+type MultistreamTargetInfo struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Profile string `json:"profile"`
+}


### PR DESCRIPTION
This is to implement processing of the Multistream webhook events sent by `mist-api-connector`, in
order to provide a target-specific Multistream status on the stream health dashboard.

Implemented this as a separate reducer, which felt like a nice experience/validation of the code architecture,
but showed how the root `"conditions"` object might need some improvement. Let's see how this evolves.