### PR TITLE
analyzer: Implement authorization on APIs

### DIFF
--- a/api/authorization.go
+++ b/api/authorization.go
@@ -36,8 +36,10 @@ func authorization(authUrl string) hitch.Middleware {
 			return
 		}
 
-		if res.StatusCode != http.StatusOK {
-			rw.Header().Set("Content-Type", res.Header.Get("Content-Type"))
+		if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNoContent {
+			if contentType := res.Header.Get("Content-Type"); contentType != "" {
+				rw.Header().Set("Content-Type", contentType)
+			}
 			rw.WriteHeader(res.StatusCode)
 			if _, err := io.Copy(rw, res.Body); err != nil {
 				glog.Errorf("Error writing auth error response. err=%q, status=%d, headers=%+v", err, res.StatusCode, res.Header)

--- a/api/authorization.go
+++ b/api/authorization.go
@@ -9,7 +9,7 @@ import (
 	"github.com/nbio/hitch"
 )
 
-var authorizationHeaders = []string{"Authorization", "Proxy-Authorization", "Cookie"}
+var authorizationHeaders = []string{"Authorization", "Cookie"}
 
 func authorization(authUrl string) hitch.Middleware {
 	return inlineMiddleware(func(rw http.ResponseWriter, r *http.Request, next http.Handler) {

--- a/api/authorization.go
+++ b/api/authorization.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/nbio/hitch"
+)
+
+
+func authorization(authUrl string) hitch.Middleware {
+	return inlineMiddleware(func(rw http.ResponseWriter, r *http.Request, next http.Handler) {
+		// TODO: Move all this to a proper client
+		status := getStreamStatus(r)
+		authReq := map[string]interface{}{
+			"resource": map[string]string{
+				"method":   r.Method,
+				"url":      r.URL.String(),
+				"streamID": status.ID,
+			},
+		}
+		payload, err := json.Marshal(authReq)
+		if err != nil {
+			respondError(rw, http.StatusInternalServerError, fmt.Errorf("error creating authorization payload: %w", err))
+			return
+		}
+		req, err := http.NewRequestWithContext(r.Context(), "POST", authUrl, bytes.NewReader(payload))
+		req.Header.Set("Content-Type", "application/json")
+		if err != nil {
+			respondError(rw, http.StatusInternalServerError, err)
+			return
+		}
+		for _, header := range []string{"Authorization", "Proxy-Authorization", "Cookie"} {
+			req.Header[header] = r.Header[header]
+		}
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			respondError(rw, http.StatusInternalServerError, fmt.Errorf("error authorizing request: %w", err))
+			return
+		}
+
+		if res.StatusCode != http.StatusOK {
+			outerErr := fmt.Errorf("authorization failed: %d %s", res.StatusCode, res.Status)
+			var errResp errorResponse
+			if err := json.NewDecoder(res.Body).Decode(&errResp); err == nil && len(errResp.Errors) > 0 {
+				outerErr = fmt.Errorf("authorization failed: %s", strings.Join(errResp.Errors, "; "))
+			}
+			respondError(rw, res.StatusCode, outerErr)
+			return
+		}
+		next.ServeHTTP(rw, r)
+	})
+}

--- a/api/authorization.go
+++ b/api/authorization.go
@@ -1,20 +1,26 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/nbio/hitch"
 )
 
 var authorizationHeaders = []string{"Authorization", "Cookie"}
+var authTimeout = 3 * time.Second
 
 func authorization(authUrl string) hitch.Middleware {
 	return inlineMiddleware(func(rw http.ResponseWriter, r *http.Request, next http.Handler) {
+		ctx, cancel := context.WithTimeout(r.Context(), authTimeout)
+		defer cancel()
+
 		status := getStreamStatus(r)
-		req, err := http.NewRequestWithContext(r.Context(), r.Method, authUrl, nil)
+		req, err := http.NewRequestWithContext(ctx, r.Method, authUrl, nil)
 		if err != nil {
 			respondError(rw, http.StatusInternalServerError, err)
 			return

--- a/api/handler.go
+++ b/api/handler.go
@@ -1,19 +1,14 @@
 package api
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"path"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/google/uuid"
 	"github.com/livepeer/livepeer-data/health"
 	"github.com/livepeer/livepeer-data/pkg/data"
 	"github.com/livepeer/livepeer-data/pkg/jsse"
@@ -24,13 +19,6 @@ const (
 	sseRetryBackoff = 10 * time.Second
 	ssePingDelay    = 20 * time.Second
 	sseBufferSize   = 128
-	proxyLoopHeader = "X-Livepeer-Proxy"
-)
-
-type contextKey int
-
-const (
-	streamStatusKey contextKey = iota
 )
 
 type APIHandlerOptions struct {
@@ -71,80 +59,6 @@ func cors(next http.Handler) http.Handler {
 		rw.Header().Set("Access-Control-Allow-Origin", "*")
 		next.ServeHTTP(rw, r)
 	})
-}
-
-func streamStatus(healthcore *health.Core, streamIDParam string) hitch.Middleware {
-	return inlineMiddleware(func(rw http.ResponseWriter, r *http.Request, next http.Handler) {
-		params := hitch.Params(r)
-		streamID := params.ByName(streamIDParam)
-		if streamID == "" {
-			next.ServeHTTP(rw, r)
-			return
-		}
-		status, err := healthcore.GetStatus(streamID)
-		if err != nil {
-			respondError(rw, http.StatusInternalServerError, err)
-			return
-		}
-		r = r.WithContext(context.WithValue(r.Context(), streamStatusKey, status))
-		next.ServeHTTP(rw, r)
-	})
-}
-
-func getStreamStatus(r *http.Request) *health.Status {
-	return r.Context().Value(streamStatusKey).(*health.Status)
-}
-
-func authorization(authUrl string) hitch.Middleware {
-	return inlineMiddleware(func(rw http.ResponseWriter, r *http.Request, next http.Handler) {
-		// TODO: Move all this to a proper client
-		status := getStreamStatus(r)
-		authReq := map[string]interface{}{
-			"resource": map[string]string{
-				"method":   r.Method,
-				"url":      r.URL.String(),
-				"streamID": status.ID,
-			},
-		}
-		payload, err := json.Marshal(authReq)
-		if err != nil {
-			respondError(rw, http.StatusInternalServerError, fmt.Errorf("error creating authorization payload: %w", err))
-			return
-		}
-		req, err := http.NewRequestWithContext(r.Context(), "POST", authUrl, bytes.NewReader(payload))
-		req.Header.Set("Content-Type", "application/json")
-		if err != nil {
-			respondError(rw, http.StatusInternalServerError, err)
-			return
-		}
-		for _, header := range []string{"Authorization", "Proxy-Authorization", "Cookie"} {
-			req.Header[header] = r.Header[header]
-		}
-		res, err := http.DefaultClient.Do(req)
-		if err != nil {
-			respondError(rw, http.StatusInternalServerError, fmt.Errorf("error authorizing request: %w", err))
-			return
-		}
-
-		if res.StatusCode != http.StatusOK {
-			outerErr := fmt.Errorf("authorization failed: %d %s", res.StatusCode, res.Status)
-			var errResp errorResponse
-			if err := json.NewDecoder(res.Body).Decode(&errResp); err == nil && len(errResp.Errors) > 0 {
-				outerErr = fmt.Errorf("authorization failed: %s", strings.Join(errResp.Errors, "; "))
-			}
-			respondError(rw, res.StatusCode, outerErr)
-			return
-		}
-		next.ServeHTTP(rw, r)
-	})
-}
-
-func inlineMiddleware(middleware func(rw http.ResponseWriter, r *http.Request, next http.Handler)) hitch.Middleware {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-			middleware(rw, r, next)
-		})
-	}
 }
 
 func (h *apiHandler) healthcheck(rw http.ResponseWriter, r *http.Request) {
@@ -250,65 +164,4 @@ func sendEvent(ctx context.Context, dest chan<- jsse.Event, evt data.Event) bool
 	case <-ctx.Done():
 		return false
 	}
-}
-
-func toSSEEvent(evt data.Event) (jsse.Event, error) {
-	data, err := json.Marshal(evt)
-	if err != nil {
-		return jsse.Event{}, err
-	}
-	return jsse.Event{
-		ID:    evt.ID().String(),
-		Event: "lp_event",
-		Data:  data,
-	}, nil
-}
-
-func parseInputTimestamp(str string) (*time.Time, error) {
-	if str == "" {
-		return nil, nil
-	}
-	t, rfcErr := time.Parse(time.RFC3339Nano, str)
-	if rfcErr == nil {
-		return &t, nil
-	}
-	ts, unixErr := strconv.ParseInt(str, 10, 64)
-	if unixErr != nil {
-		return nil, fmt.Errorf("bad time %q. must be in RFC3339 or Unix Timestamp (millisecond) formats. rfcErr: %s; unixErr: %s", str, rfcErr, unixErr)
-	}
-	t = data.NewUnixMillisTime(ts).Time
-	return &t, nil
-}
-
-func parseInputUUID(str string) (*uuid.UUID, error) {
-	if str == "" {
-		return nil, nil
-	}
-	uuid, err := uuid.Parse(str)
-	if err != nil {
-		return nil, fmt.Errorf("bad uuid %q: %w", str, err)
-	}
-	return &uuid, nil
-}
-
-func unionCtx(ctx1, ctx2 context.Context) (context.Context, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		defer cancel()
-		select {
-		case <-ctx1.Done():
-		case <-ctx2.Done():
-		}
-	}()
-	return ctx, cancel
-}
-
-func nonNilErrs(errs ...error) []error {
-	var nonNil []error
-	for _, err := range errs {
-		if err != nil {
-			nonNil = append(nonNil, err)
-		}
-	}
-	return nonNil
 }

--- a/api/handler.go
+++ b/api/handler.go
@@ -57,6 +57,7 @@ func NewHandler(serverCtx context.Context, opts APIHandlerOptions, healthcore *h
 func cors(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		rw.Header().Set("Access-Control-Allow-Origin", "*")
+		rw.Header().Set("Access-Control-Allow-Headers", "*")
 		next.ServeHTTP(rw, r)
 	})
 }

--- a/api/regionProxy.go
+++ b/api/regionProxy.go
@@ -12,6 +12,8 @@ import (
 	"github.com/nbio/hitch"
 )
 
+const proxyLoopHeader = "X-Livepeer-Proxy"
+
 func regionProxy(hostFormat, ownRegion string) hitch.Middleware {
 	proxy := &httputil.ReverseProxy{
 		Director:      regionProxyDirector(hostFormat),

--- a/api/regionProxy.go
+++ b/api/regionProxy.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/livepeer/livepeer-data/health/reducers"
+	"github.com/nbio/hitch"
+)
+
+func regionProxy(hostFormat, ownRegion string) hitch.Middleware {
+	proxy := &httputil.ReverseProxy{
+		Director:      regionProxyDirector(hostFormat),
+		FlushInterval: 100 * time.Millisecond,
+	}
+	return inlineMiddleware(func(rw http.ResponseWriter, r *http.Request, next http.Handler) {
+		status := getStreamStatus(r)
+		streamRegion := reducers.GetLastActiveData(status).Region
+		if ownRegion == "" || streamRegion == "" || streamRegion == ownRegion {
+			next.ServeHTTP(rw, r)
+			return
+		}
+		if _, ok := r.Header[proxyLoopHeader]; ok {
+			respondError(rw, http.StatusLoopDetected, errors.New("proxy loop detected"))
+			return
+		}
+		proxy.ServeHTTP(rw, r)
+	})
+}
+
+func regionProxyDirector(hostFormat string) func(req *http.Request) {
+	return func(req *http.Request) {
+		glog.V(8).Infof("Proxying request url=%s headers=%+v", req.URL, req.Header)
+		status := getStreamStatus(req)
+		streamRegion := reducers.GetLastActiveData(status).Region
+
+		req.URL.Scheme = "http"
+		if fwdProto := req.Header.Get("X-Forwarded-Proto"); fwdProto != "" {
+			req.URL.Scheme = fwdProto
+		}
+		req.URL.Host = fmt.Sprintf(hostFormat, streamRegion)
+		req.Host = req.URL.Host
+
+		req.Header.Set(proxyLoopHeader, "analyzer")
+		if _, ok := req.Header["User-Agent"]; !ok {
+			// explicitly disable User-Agent so it's not set to default value
+			req.Header.Set("User-Agent", "")
+		}
+	}
+}

--- a/api/streamStatus.go
+++ b/api/streamStatus.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/livepeer/livepeer-data/health"
+	"github.com/nbio/hitch"
+)
+
+type contextKey int
+
+const (
+	streamStatusKey contextKey = iota
+)
+
+func streamStatus(healthcore *health.Core, streamIDParam string) hitch.Middleware {
+	return inlineMiddleware(func(rw http.ResponseWriter, r *http.Request, next http.Handler) {
+		params := hitch.Params(r)
+		streamID := params.ByName(streamIDParam)
+		if streamID == "" {
+			next.ServeHTTP(rw, r)
+			return
+		}
+		status, err := healthcore.GetStatus(streamID)
+		if err != nil {
+			respondError(rw, http.StatusInternalServerError, err)
+			return
+		}
+		r = r.WithContext(context.WithValue(r.Context(), streamStatusKey, status))
+		next.ServeHTTP(rw, r)
+	})
+}
+
+func getStreamStatus(r *http.Request) *health.Status {
+	return r.Context().Value(streamStatusKey).(*health.Status)
+}

--- a/api/util.go
+++ b/api/util.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/livepeer/livepeer-data/pkg/data"
+	"github.com/livepeer/livepeer-data/pkg/jsse"
+	"github.com/nbio/hitch"
+)
+
+func inlineMiddleware(middleware func(rw http.ResponseWriter, r *http.Request, next http.Handler)) hitch.Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			middleware(rw, r, next)
+		})
+	}
+}
+
+func toSSEEvent(evt data.Event) (jsse.Event, error) {
+	data, err := json.Marshal(evt)
+	if err != nil {
+		return jsse.Event{}, err
+	}
+	return jsse.Event{
+		ID:    evt.ID().String(),
+		Event: "lp_event",
+		Data:  data,
+	}, nil
+}
+
+func parseInputTimestamp(str string) (*time.Time, error) {
+	if str == "" {
+		return nil, nil
+	}
+	t, rfcErr := time.Parse(time.RFC3339Nano, str)
+	if rfcErr == nil {
+		return &t, nil
+	}
+	ts, unixErr := strconv.ParseInt(str, 10, 64)
+	if unixErr != nil {
+		return nil, fmt.Errorf("bad time %q. must be in RFC3339 or Unix Timestamp (millisecond) formats. rfcErr: %s; unixErr: %s", str, rfcErr, unixErr)
+	}
+	t = data.NewUnixMillisTime(ts).Time
+	return &t, nil
+}
+
+func parseInputUUID(str string) (*uuid.UUID, error) {
+	if str == "" {
+		return nil, nil
+	}
+	uuid, err := uuid.Parse(str)
+	if err != nil {
+		return nil, fmt.Errorf("bad uuid %q: %w", str, err)
+	}
+	return &uuid, nil
+}
+
+func unionCtx(ctx1, ctx2 context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		defer cancel()
+		select {
+		case <-ctx1.Done():
+		case <-ctx2.Done():
+		}
+	}()
+	return ctx, cancel
+}
+
+func nonNilErrs(errs ...error) []error {
+	var nonNil []error
+	for _, err := range errs {
+		if err != nil {
+			nonNil = append(nonNil, err)
+		}
+	}
+	return nonNil
+}

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -48,10 +48,12 @@ func init() {
 	// Server options
 	fs.StringVar(&serverOpts.Host, "host", "localhost", "Hostname to bind to")
 	fs.UintVar(&serverOpts.Port, "port", 8080, "Port to listen on")
+	fs.DurationVar(&serverOpts.ShutdownGracePeriod, "shutdown-grace-perod", 15*time.Second, "Grace period to wait for server shutdown before using the force")
+	// API Handler
 	fs.StringVar(&serverOpts.APIRoot, "api-root", "/data", "Root path where to bind the API to")
+	fs.StringVar(&serverOpts.AuthURL, "auth-url", "", "Endpoint for an auth server to call for both authentication and authorization of API calls")
 	fs.StringVar(&serverOpts.OwnRegion, "own-region", "", "Identifier of the region where the service is running, used for triggering global request proxying")
 	fs.StringVar(&serverOpts.RegionalHostFormat, "regional-host-format", "localhost", "Format to build regional URL for proxying to other regions. Should contain 1 %s directive where the region will be replaced (e.g. %s.livepeer.monster)")
-	fs.DurationVar(&serverOpts.ShutdownGracePeriod, "shutdown-grace-perod", 15*time.Second, "Grace period to wait for server shutdown before using the force")
 
 	// Streaming options
 	fs.StringVar(&streamingOpts.Stream, "rabbitmq-stream-name", "lp_stream_health_v0", "Name of RabbitMQ stream to create and consume from")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,9 @@ services:
       rabbitmq-plugins enable --offline rabbitmq_stream
       bash <<EOF &
         until rabbitmqadmin --vhost=livepeer declare exchange name=lp_golivepeer_metadata type=topic && \
-              rabbitmqadmin --vhost=livepeer declare exchange name=webhook_default_exchange type=topic; do
+              rabbitmqadmin --vhost=livepeer declare exchange name=webhook_default_exchange type=topic && \
+              rabbitmqadmin --vhost=livepeer declare exchange name=lp_mist_api_connector type=topic && \
+              rabbitmqadmin --vhost=livepeer declare exchange name=lp_global_replication type=topic; do
           sleep 1;
         done
       EOF

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/golang/glog v0.0.0-20210429001901-424d2337a529
 	github.com/google/uuid v1.3.0
-	github.com/julienschmidt/httprouter v1.3.0
+	github.com/nbio/hitch v0.0.0-20200727225606-6dd6dd293f2b
 	github.com/peterbourgon/ff v1.7.0
 	github.com/rabbitmq/amqp091-go v1.1.0
 	github.com/rabbitmq/rabbitmq-stream-go-client v0.1.0-beta.0.20211027081212-fd5e6d497413

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,8 @@ github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/nbio/hitch v0.0.0-20200727225606-6dd6dd293f2b h1:QJUXCpedBGJiNQ32//pf7i57fJpwMD18FhG0bEkv6WI=
+github.com/nbio/hitch v0.0.0-20200727225606-6dd6dd293f2b/go.mod h1:pCpSEQ+v0QJ68bwwrFH5BRKkPQyZUlKcxcYhIAlq48U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/health/reducers/media_server_metrics.go
+++ b/health/reducers/media_server_metrics.go
@@ -38,7 +38,7 @@ func (t MediaServerMetrics) Reduce(current *health.Status, _ interface{}, evtIfa
 	}
 
 	metrics := current.MetricsCopy()
-	ts, dims := evt.Timestamp(), map[string]string{"nodeId": evt.NodeID}
+	ts, dims := evt.Timestamp(), map[string]string{"region": evt.Region, "nodeId": evt.NodeID}
 	if evt.Stats.MediaTimeMs != nil {
 		metrics.Add(health.NewMetric(MetricMediaTimeMillis, dims, ts, float64(*evt.Stats.MediaTimeMs)))
 	}


### PR DESCRIPTION
This is to implement authorization to the stream health APis by leveraging from the new API created
in livepeer-com: https://github.com/livepeer/livepeer-com/pull/682

The main logical change here was that I introduced this new simples midldewares library for the
API handler (hitch). It's very minimal to the point that I just read its whole code and it looks just like
what I thought of implemented myself, so we might as well delegate it (and go.sum will save us from
any bad updates anyway).

Also included a few other changes in here like adding a little more logs around the code, since I've
started feeling that `analyzer` is currently very black-box-y when it's running in production. So this
will improve that a bit.

This implements https://github.com/livepeer/livepeer-data/issues/4.