### PR TITLE
analyzer: Fix handling of stream status when a new session starts

### DIFF
--- a/health/record.go
+++ b/health/record.go
@@ -25,22 +25,18 @@ type Record struct {
 	LastStatus   *Status
 }
 
-func NewRecord(id string, conditions []ConditionType) *Record {
-	rec := &Record{
+func NewRecord(id string, conditionTypes []ConditionType) *Record {
+	conditions := make([]*Condition, len(conditionTypes))
+	for i, cond := range conditionTypes {
+		conditions[i] = NewCondition(cond, time.Time{}, nil, nil)
+	}
+	return &Record{
 		ID:         id,
-		Conditions: conditions,
+		Conditions: conditionTypes,
 		disposed:   make(chan struct{}),
 		EventsByID: map[uuid.UUID]data.Event{},
-		LastStatus: &Status{
-			ID:         id,
-			Healthy:    NewCondition("", time.Time{}, nil, nil),
-			Conditions: make([]*Condition, len(conditions)),
-		},
+		LastStatus: NewStatus(id, conditions),
 	}
-	for i, cond := range conditions {
-		rec.LastStatus.Conditions[i] = NewCondition(cond, time.Time{}, nil, nil)
-	}
-	return rec
 }
 
 func (r *Record) SubscribeLocked(ctx context.Context, subs chan data.Event) chan data.Event {

--- a/health/reducers/stream_state.go
+++ b/health/reducers/stream_state.go
@@ -37,7 +37,8 @@ func (t StreamStateReducer) Reduce(current *health.Status, _ interface{}, evtIfa
 	glog.Infof("Stream state event: region=%s stream=%s active=%v", evt.Region, evt.StreamID(), evt.State.Active)
 
 	last := GetLastActiveData(current)
-	if !evt.State.Active && (evt.NodeID != last.NodeID || evt.Region != last.Region) {
+	hasLast := last.NodeID != "" && last.Region != ""
+	if !evt.State.Active && hasLast && (evt.NodeID != last.NodeID || evt.Region != last.Region) {
 		glog.Infof("Ignoring inactive stream state event from previous session: region=%s stream=%s", evt.Region, evt.StreamID())
 		return current, nil
 	}

--- a/health/types.go
+++ b/health/types.go
@@ -61,6 +61,16 @@ type Measure struct {
 
 // Status
 
+func NewStatus(id string, conditions []*Condition) *Status {
+	return &Status{
+		ID:          id,
+		Healthy:     NewCondition("", time.Time{}, nil, nil),
+		Conditions:  conditions,
+		Metrics:     MetricsMap{},
+		Multistream: []*MultistreamStatus{},
+	}
+}
+
 func NewMergedStatus(base *Status, values Status) *Status {
 	if base == nil {
 		return &values


### PR DESCRIPTION
We currently carry-over state from previous sessions to the next, which makes a lot of
stuff in the dashboard display weirdly when we start a new stream. i.e. the API response
payloads are weird cause they keep information about previous sessions.

This fixes that by actually clearing the stream state when we process an event about a stream
becoming active. 

The right long-term approach would be to index these heath status by session ID instead so
we don't mix them together, but IMO this is the best approach for now, since indexing by session ID
would require adding that context to every place we currently send events from, including for
example `mist-api-connector`. So we can keep that one for sometime later.