### PR TITLE
analyzer: Fix CORS when region-proxying a request

### DIFF
--- a/api/regionProxy.go
+++ b/api/regionProxy.go
@@ -30,6 +30,11 @@ func regionProxy(hostFormat, ownRegion string) hitch.Middleware {
 			respondError(rw, http.StatusLoopDetected, errors.New("proxy loop detected"))
 			return
 		}
+		// Clear any header we may have already set (e.g. CORS) to forward the
+		// response from the other region exactly as is.
+		for h := range rw.Header() {
+			rw.Header().Del(h)
+		}
 		proxy.ServeHTTP(rw, r)
 	})
 }


### PR DESCRIPTION
We were responding with multiple CORS headers which is invalid.

I thought about just moving the middlewares order as well, but that would imply that 404 responses
coming from the `streamStatus` would not get the CORS headers and then weird errors as well.

I think this fix makes conceptual sense as well, so I'm ok with it, but lmk of any other ideas that might
work out better. The other entrypoint we would have is `ReverseProxy`'s `ModifyResponse`, but didn't
think that was very good either.