### PR TITLE
pkg/client: Create client for analyzer API

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -10,7 +10,7 @@ import (
 )
 
 type errorResponse struct {
-	Errors []string
+	Errors []string `json:"errors"`
 }
 
 func respondError(rw http.ResponseWriter, defaultStatus int, errs ...error) {

--- a/api/streamStatus.go
+++ b/api/streamStatus.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/livepeer/livepeer-data/health"
+	"github.com/livepeer/livepeer-data/pkg/data"
 	"github.com/nbio/hitch"
 )
 
@@ -32,6 +33,6 @@ func streamStatus(healthcore *health.Core, streamIDParam string) hitch.Middlewar
 	})
 }
 
-func getStreamStatus(r *http.Request) *health.Status {
-	return r.Context().Value(streamStatusKey).(*health.Status)
+func getStreamStatus(r *http.Request) *data.HealthStatus {
+	return r.Context().Value(streamStatusKey).(*data.HealthStatus)
 }

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -72,6 +72,7 @@ func init() {
 		ff.WithConfigFileFlag("config"),
 		ff.WithConfigFileParser(ff.PlainParser),
 		ff.WithEnvVarPrefix("LP"),
+		ff.WithEnvVarIgnoreCommas(true),
 	)
 	flag.CommandLine.Parse(nil)
 	glogVFlag.Value.Set(strconv.Itoa(*verbosity))

--- a/health/core.go
+++ b/health/core.go
@@ -41,7 +41,7 @@ type Core struct {
 	started  bool
 
 	reducer        Reducer
-	conditionTypes []ConditionType
+	conditionTypes []data.ConditionType
 
 	storage RecordStorage
 }
@@ -130,7 +130,7 @@ func (c *Core) handleSingleEvent(evt data.Event) {
 	}
 }
 
-func (c *Core) GetStatus(manifestID string) (*Status, error) {
+func (c *Core) GetStatus(manifestID string) (*data.HealthStatus, error) {
 	record, ok := c.storage.Get(manifestID)
 	if !ok {
 		return nil, ErrStreamNotFound

--- a/health/record.go
+++ b/health/record.go
@@ -12,7 +12,7 @@ import (
 
 type Record struct {
 	ID         string
-	Conditions []ConditionType
+	Conditions []data.ConditionType
 
 	sync.RWMutex
 	disposed chan struct{}
@@ -22,20 +22,20 @@ type Record struct {
 	EventSubs  []chan<- data.Event
 
 	ReducerState interface{}
-	LastStatus   *Status
+	LastStatus   *data.HealthStatus
 }
 
-func NewRecord(id string, conditionTypes []ConditionType) *Record {
-	conditions := make([]*Condition, len(conditionTypes))
+func NewRecord(id string, conditionTypes []data.ConditionType) *Record {
+	conditions := make([]*data.Condition, len(conditionTypes))
 	for i, cond := range conditionTypes {
-		conditions[i] = NewCondition(cond, time.Time{}, nil, nil)
+		conditions[i] = data.NewCondition(cond, time.Time{}, nil, nil)
 	}
 	return &Record{
 		ID:         id,
 		Conditions: conditionTypes,
 		disposed:   make(chan struct{}),
 		EventsByID: map[uuid.UUID]data.Event{},
-		LastStatus: NewStatus(id, conditions),
+		LastStatus: data.NewHealthStatus(id, conditions),
 	}
 }
 
@@ -102,7 +102,7 @@ func (s *RecordStorage) Get(id string) (*Record, bool) {
 	return nil, false
 }
 
-func (s *RecordStorage) GetOrCreate(id string, conditions []ConditionType) *Record {
+func (s *RecordStorage) GetOrCreate(id string, conditions []data.ConditionType) *Record {
 	if saved, ok := s.Get(id); ok {
 		return saved
 	}

--- a/health/reducer.go
+++ b/health/reducer.go
@@ -7,14 +7,14 @@ import (
 
 type Reducer interface {
 	Bindings() []event.BindingArgs
-	Conditions() []ConditionType
-	Reduce(current *Status, state interface{}, evt data.Event) (*Status, interface{})
+	Conditions() []data.ConditionType
+	Reduce(current *data.HealthStatus, state interface{}, evt data.Event) (*data.HealthStatus, interface{})
 }
 
-type ReducerFunc func(*Status, interface{}, data.Event) (*Status, interface{})
+type ReducerFunc func(*data.HealthStatus, interface{}, data.Event) (*data.HealthStatus, interface{})
 
-func (f ReducerFunc) Bindings() []event.BindingArgs { return nil }
-func (f ReducerFunc) Conditions() []ConditionType   { return nil }
-func (f ReducerFunc) Reduce(current *Status, state interface{}, evt data.Event) (*Status, interface{}) {
+func (f ReducerFunc) Bindings() []event.BindingArgs    { return nil }
+func (f ReducerFunc) Conditions() []data.ConditionType { return nil }
+func (f ReducerFunc) Reduce(current *data.HealthStatus, state interface{}, evt data.Event) (*data.HealthStatus, interface{}) {
 	return f(current, state, evt)
 }

--- a/health/reducers/health.go
+++ b/health/reducers/health.go
@@ -5,7 +5,7 @@ import (
 	"github.com/livepeer/livepeer-data/pkg/data"
 )
 
-var healthyRequirementDefaults = map[health.ConditionType]bool{
+var healthyRequirementDefaults = map[data.ConditionType]bool{
 	ConditionTranscoding:       false,
 	ConditionTranscodeRealTime: false,
 	ConditionMultistreaming:    true,
@@ -13,7 +13,7 @@ var healthyRequirementDefaults = map[health.ConditionType]bool{
 
 var HealthReducer = health.ReducerFunc(reduceHealth)
 
-func reduceHealth(current *health.Status, _ interface{}, evt data.Event) (*health.Status, interface{}) {
+func reduceHealth(current *data.HealthStatus, _ interface{}, evt data.Event) (*data.HealthStatus, interface{}) {
 	isHealthy := true
 	for _, cond := range current.Conditions {
 		status, isRequired := healthyRequirementDefaults[cond.Type]
@@ -28,7 +28,7 @@ func reduceHealth(current *health.Status, _ interface{}, evt data.Event) (*healt
 			break
 		}
 	}
-	healthyCond := health.NewCondition("", evt.Timestamp(), &isHealthy, current.Healthy)
+	healthyCond := data.NewCondition("", evt.Timestamp(), &isHealthy, current.Healthy)
 
-	return health.NewMergedStatus(current, health.Status{Healthy: healthyCond}), nil
+	return data.NewMergedHealthStatus(current, data.HealthStatus{Healthy: healthyCond}), nil
 }

--- a/health/reducers/pipeline.go
+++ b/health/reducers/pipeline.go
@@ -26,9 +26,9 @@ func (p Pipeline) Bindings() []event.BindingArgs {
 	return bindings
 }
 
-func (p Pipeline) Conditions() []health.ConditionType {
-	added := map[health.ConditionType]bool{}
-	conds := []health.ConditionType{}
+func (p Pipeline) Conditions() []data.ConditionType {
+	added := map[data.ConditionType]bool{}
+	conds := []data.ConditionType{}
 	for _, reducer := range p {
 		for _, newCond := range reducer.Conditions() {
 			if added[newCond] {
@@ -42,7 +42,7 @@ func (p Pipeline) Conditions() []health.ConditionType {
 	return conds
 }
 
-func (p Pipeline) Reduce(current *health.Status, stateIface interface{}, evt data.Event) (*health.Status, interface{}) {
+func (p Pipeline) Reduce(current *data.HealthStatus, stateIface interface{}, evt data.Event) (*data.HealthStatus, interface{}) {
 	var state []interface{}
 	if stateIface != nil {
 		state = stateIface.([]interface{})

--- a/pkg/client/analyzer.go
+++ b/pkg/client/analyzer.go
@@ -90,7 +90,9 @@ func (a *analyzer) doGet(ctx context.Context, url string) ([]byte, error) {
 			url, resp.StatusCode, took, string(body))
 	}
 	if resp.StatusCode != http.StatusOK {
-		glog.Errorf("Status error from analyzer url=%q, status=%d, body=%q", url, resp.StatusCode, string(body))
+		if glog.V(7) || resp.StatusCode != http.StatusNotFound {
+			glog.Errorf("Status error from analyzer url=%q, status=%d, body=%q", url, resp.StatusCode, string(body))
+		}
 		var errResp errorResponse
 		if err := json.Unmarshal(body, &errResp); err != nil {
 			glog.Errorf("Failed to parse error response url=%q, status=%d, err=%q", url, resp.StatusCode, err)

--- a/pkg/client/analyzer.go
+++ b/pkg/client/analyzer.go
@@ -1,0 +1,113 @@
+// Package client contains clients for the Stream Health analyzer public API.
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/livepeer/livepeer-data/pkg/data"
+)
+
+type (
+	// Analyzer abstracts the stream health analyzer APIs.
+	Analyzer interface {
+		GetStreamHealth(ctx context.Context, streamID string) (*data.HealthStatus, error)
+	}
+
+	errorResponse struct {
+		Errors []string `json:"errors"`
+	}
+
+	analyzer struct {
+		baseUrl    string
+		userAgent  string
+		authToken  string
+		httpClient *http.Client
+	}
+)
+
+// NewAnalyzer creates a client for the stream health analyzer service.
+func NewAnalyzer(baseUrl, authToken, userAgent string, timeout time.Duration) Analyzer {
+	if timeout <= 0 {
+		timeout = 4 * time.Second
+	}
+	return &analyzer{
+		baseUrl:   addScheme(baseUrl),
+		authToken: authToken,
+		userAgent: userAgent,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+	}
+}
+
+func (a *analyzer) GetStreamHealth(ctx context.Context, streamID string) (*data.HealthStatus, error) {
+	url := fmt.Sprintf("%s/data/stream/%s/health", a.baseUrl, streamID)
+	body, err := a.doGet(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+
+	var health *data.HealthStatus
+	if err = json.Unmarshal(body, &health); err != nil {
+		glog.Errorf("Error parsing stream health response from Analyzer url=%q, err=%q, body=%q", url, err, string(body))
+		return nil, err
+	}
+	return health, nil
+}
+
+func (a *analyzer) doGet(ctx context.Context, url string) ([]byte, error) {
+	start := time.Now()
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %w", err)
+	}
+	req.Header.Add("Authorization", "Bearer "+a.authToken)
+	if a.userAgent != "" {
+		req.Header.Add("User-Agent", a.userAgent)
+	}
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		glog.Errorf("Get request error to analyzer url=%q, err=%q", url, err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		glog.Errorf("Error reading analyzer response body url=%q, status=%d, error=%q", url, resp.StatusCode, err)
+		return nil, err
+	}
+	if glog.V(7) {
+		took := time.Since(start)
+		glog.Infof("Analyzer get request done url=%q, status=%d, latency=%v, body=%q",
+			url, resp.StatusCode, took, string(body))
+	}
+	if resp.StatusCode != http.StatusOK {
+		glog.Errorf("Status error from analyzer url=%q, status=%d, body=%q", url, resp.StatusCode, string(body))
+		var errResp errorResponse
+		if err := json.Unmarshal(body, &errResp); err != nil {
+			glog.Errorf("Failed to parse error response url=%q, status=%d, err=%q", url, resp.StatusCode, err)
+			errResp.Errors = []string{string(body)}
+		}
+		return nil, APIError{resp.StatusCode, errResp.Errors}
+	}
+	return body, nil
+}
+
+func addScheme(url string) string {
+	url = strings.ToLower(url)
+	if url == "" || strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
+		return url
+	}
+	if strings.Contains(url, ".local") || strings.HasPrefix(url, "localhost") {
+		return "http://" + url
+	}
+	return "https://" + url
+}

--- a/pkg/client/analyzer.go
+++ b/pkg/client/analyzer.go
@@ -96,7 +96,7 @@ func (a *analyzer) doGet(ctx context.Context, url string) ([]byte, error) {
 		var errResp errorResponse
 		if err := json.Unmarshal(body, &errResp); err != nil {
 			glog.Errorf("Failed to parse error response url=%q, status=%d, err=%q", url, resp.StatusCode, err)
-			errResp.Errors = []string{string(body)}
+			errResp.Errors = []string{strings.TrimSpace(string(body))}
 		}
 		return nil, APIError{resp.StatusCode, errResp.Errors}
 	}

--- a/pkg/client/apiError.go
+++ b/pkg/client/apiError.go
@@ -1,0 +1,21 @@
+package client
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+)
+
+type APIError struct {
+	StatusCode int
+	Errors     []string
+}
+
+func (h APIError) Error() string {
+	return strings.Join(h.Errors, "; ")
+}
+
+func IsNotFound(err error) bool {
+	var apiErr APIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound
+}


### PR DESCRIPTION
This is to create a public package with an HTTP client for the Stream Health analyzer API.

To be used by `stream-tester` for testing Stream Health availability.

Only including `/health` API initially which is the minimum we need. 
SSE will either need adding a third-party library or writing some custom parsing logic, so
will leave it for when we really need it. Would be really awesome to POC that idea of
implementing the same reducer logic in the client code though.