### PR TITLE
pkg/event: Create AMQP consumer client

### DIFF
--- a/pkg/event/amqp_client.go
+++ b/pkg/event/amqp_client.go
@@ -1,0 +1,28 @@
+package event
+
+import "context"
+
+type amqpClient struct {
+	AMQPConsumer
+	AMQPProducer
+}
+
+func NewAMQPClient(uri string, connectFn AMQPConnectFunc) (AMQPClient, error) {
+	consumer, err := NewAMQPConsumer(uri, connectFn)
+	if err != nil {
+		return nil, err
+	}
+	producer, err := NewAMQPProducer(uri, connectFn)
+	if err != nil {
+		consumer.Shutdown(context.Background())
+		return nil, err
+	}
+	return &amqpClient{consumer, producer}, nil
+}
+
+func (c *amqpClient) Shutdown(ctx context.Context) error {
+	if err := c.AMQPConsumer.Shutdown(ctx); err != nil {
+		return err
+	}
+	return c.AMQPProducer.Shutdown(ctx)
+}

--- a/pkg/event/amqp_conn.go
+++ b/pkg/event/amqp_conn.go
@@ -13,18 +13,17 @@ type AMQPChanOps interface {
 }
 
 type AMQPChanSetup interface {
-	ExchangeBind(string, string, string, bool, amqp.Table) error
-	ExchangeDeclare(string, string, bool, bool, bool, bool, amqp.Table) error
-	ExchangeDeclarePassive(string, string, bool, bool, bool, bool, amqp.Table) error
-	ExchangeDelete(string, bool, bool) error
-	ExchangeUnbind(string, string, string, bool, amqp.Table) error
-	QueueBind(string, string, string, bool, amqp.Table) error
-	QueueDeclare(string, bool, bool, bool, bool, amqp.Table) (amqp.Queue, error)
-	QueueDeclarePassive(string, bool, bool, bool, bool, amqp.Table) (amqp.Queue, error)
-	QueueDelete(string, bool, bool, bool) (int, error)
-	QueueInspect(string) (amqp.Queue, error)
-	QueuePurge(string, bool) (int, error)
-	QueueUnbind(string, string, string, amqp.Table) error
+	ExchangeBind(destination, key, source string, noWait bool, args amqp.Table) error
+	ExchangeDeclare(name, kind string, durable, autoDelete, internal, noWait bool, args amqp.Table) error
+	ExchangeDeclarePassive(name, kind string, durable, autoDelete, internal, noWait bool, args amqp.Table) error
+	ExchangeDelete(name string, ifUnused, noWait bool) error
+	ExchangeUnbind(destination, key, source string, noWait bool, args amqp.Table) error
+	QueueBind(name, key, exchange string, noWait bool, args amqp.Table) error
+	QueueDeclare(name string, durable, autoDelete, exclusive, noWait bool, args amqp.Table) (amqp.Queue, error)
+	QueueDeclarePassive(name string, durable, autoDelete, exclusive, noWait bool, args amqp.Table) (amqp.Queue, error)
+	QueueDelete(name string, ifUnused, ifEmpty, noWait bool) (int, error)
+	QueueInspect(name string) (amqp.Queue, error)
+	QueueUnbind(name, key, exchange string, args amqp.Table) error
 }
 
 type AMQPConnectFunc func(ctx context.Context, uri string, confirms chan amqp.Confirmation, closed chan *amqp.Error) (AMQPChanOps, error)

--- a/pkg/event/amqp_conn.go
+++ b/pkg/event/amqp_conn.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/rabbitmq/amqp091-go"
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
@@ -14,18 +13,18 @@ type AMQPChanOps interface {
 }
 
 type AMQPChanSetup interface {
-	ExchangeBind(string, string, string, bool, amqp091.Table) error
-	ExchangeDeclare(string, string, bool, bool, bool, bool, amqp091.Table) error
-	ExchangeDeclarePassive(string, string, bool, bool, bool, bool, amqp091.Table) error
+	ExchangeBind(string, string, string, bool, amqp.Table) error
+	ExchangeDeclare(string, string, bool, bool, bool, bool, amqp.Table) error
+	ExchangeDeclarePassive(string, string, bool, bool, bool, bool, amqp.Table) error
 	ExchangeDelete(string, bool, bool) error
-	ExchangeUnbind(string, string, string, bool, amqp091.Table) error
-	QueueBind(string, string, string, bool, amqp091.Table) error
-	QueueDeclare(string, bool, bool, bool, bool, amqp091.Table) (amqp091.Queue, error)
-	QueueDeclarePassive(string, bool, bool, bool, bool, amqp091.Table) (amqp091.Queue, error)
+	ExchangeUnbind(string, string, string, bool, amqp.Table) error
+	QueueBind(string, string, string, bool, amqp.Table) error
+	QueueDeclare(string, bool, bool, bool, bool, amqp.Table) (amqp.Queue, error)
+	QueueDeclarePassive(string, bool, bool, bool, bool, amqp.Table) (amqp.Queue, error)
 	QueueDelete(string, bool, bool, bool) (int, error)
-	QueueInspect(string) (amqp091.Queue, error)
+	QueueInspect(string) (amqp.Queue, error)
 	QueuePurge(string, bool) (int, error)
-	QueueUnbind(string, string, string, amqp091.Table) error
+	QueueUnbind(string, string, string, amqp.Table) error
 }
 
 type AMQPConnectFunc func(ctx context.Context, uri string, confirms chan amqp.Confirmation, closed chan *amqp.Error) (AMQPChanOps, error)

--- a/pkg/event/amqp_conn.go
+++ b/pkg/event/amqp_conn.go
@@ -11,8 +11,6 @@ import (
 type AMQPChanOps interface {
 	Publish(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error
 	Consume(queue, consumer string, autoAck, exclusive, noLocal, noWait bool, args amqp.Table) (<-chan amqp.Delivery, error)
-	Ack(uint64, bool) error
-	Nack(uint64, bool, bool) error
 }
 
 type AMQPChanSetup interface {

--- a/pkg/event/amqp_conn.go
+++ b/pkg/event/amqp_conn.go
@@ -1,0 +1,69 @@
+package event
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rabbitmq/amqp091-go"
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+type AMQPChanOps interface {
+	Publish(exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error
+	Consume(queue, consumer string, autoAck, exclusive, noLocal, noWait bool, args amqp.Table) (<-chan amqp.Delivery, error)
+	Ack(uint64, bool) error
+	Nack(uint64, bool, bool) error
+}
+
+type AMQPChanSetup interface {
+	ExchangeBind(string, string, string, bool, amqp091.Table) error
+	ExchangeDeclare(string, string, bool, bool, bool, bool, amqp091.Table) error
+	ExchangeDeclarePassive(string, string, bool, bool, bool, bool, amqp091.Table) error
+	ExchangeDelete(string, bool, bool) error
+	ExchangeUnbind(string, string, string, bool, amqp091.Table) error
+	QueueBind(string, string, string, bool, amqp091.Table) error
+	QueueDeclare(string, bool, bool, bool, bool, amqp091.Table) (amqp091.Queue, error)
+	QueueDeclarePassive(string, bool, bool, bool, bool, amqp091.Table) (amqp091.Queue, error)
+	QueueDelete(string, bool, bool, bool) (int, error)
+	QueueInspect(string) (amqp091.Queue, error)
+	QueuePurge(string, bool) (int, error)
+	QueueUnbind(string, string, string, amqp091.Table) error
+}
+
+type AMQPConnectFunc func(ctx context.Context, uri string, confirms chan amqp.Confirmation, closed chan *amqp.Error) (AMQPChanOps, error)
+
+func NewAMQPConnectFunc(setup func(c AMQPChanSetup) error) AMQPConnectFunc {
+	return func(ctx context.Context, uri string, confirms chan amqp.Confirmation, closed chan *amqp.Error) (AMQPChanOps, error) {
+		conn, err := amqp.Dial(uri)
+		if err != nil {
+			return nil, fmt.Errorf("dial: %w", err)
+		}
+		go func() {
+			<-ctx.Done()
+			conn.Close()
+		}()
+
+		channel, err := conn.Channel()
+		if err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("open channel: %w", err)
+		}
+		if err := channel.Confirm(false); err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("request confirms: %w", err)
+		}
+		if setup != nil {
+			if err := setup(channel); err != nil {
+				conn.Close()
+				return nil, fmt.Errorf("channel setup: %w", err)
+			}
+		}
+		if confirms != nil {
+			channel.NotifyPublish(confirms)
+		}
+		if closed != nil {
+			channel.NotifyClose(closed)
+		}
+		return channel, nil
+	}
+}

--- a/pkg/event/amqp_consumer.go
+++ b/pkg/event/amqp_consumer.go
@@ -1,0 +1,167 @@
+package event
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+var ErrConsumerClosed = errors.New("amqp: consumer closed")
+
+type AMQPMessageHandler func(amqp.Delivery) error
+
+type subscription struct {
+	queue       string
+	handler     AMQPMessageHandler
+	concurrency int
+}
+
+type AMQPConsumer struct {
+	amqpURI   string
+	connectFn AMQPConnectFunc
+
+	lock          sync.Mutex
+	subscriptions []*subscription
+	currChannel   AMQPChanOps
+	currCtx       context.Context
+
+	shutdownCtx context.Context
+	shutdown    context.CancelFunc
+}
+
+func NewAMQPConsumer(uri string, connectFn AMQPConnectFunc) (*AMQPConsumer, error) {
+	shutCtx, shutdown := context.WithCancel(context.Background())
+	amqp := &AMQPConsumer{
+		amqpURI:   uri,
+		connectFn: connectFn,
+		// subsChan:      make(chan *subscription, 5),
+		shutdownCtx: shutCtx,
+		shutdown:    shutdown,
+	}
+	if err := amqp.connect(); err != nil {
+		return nil, err
+	}
+	go amqp.reconnectLoop()
+	return amqp, nil
+}
+
+// Shutdown will try to gracefully stop the background event consuming process.
+func (c *AMQPConsumer) Shutdown() error {
+	c.shutdown()
+	return nil
+}
+
+// Consume starts consuming messages from the given queue and calls the provided
+// function for each message. The function will be called concurrently at most
+// the given number of times. Returning a `nil` error will automatically
+// acknowledge the message, whilst an error will cause it to be re-queued
+// (nacked).
+//
+// There is currently no way to cancel a consumption after it has started.
+// Shutdown the whole consumer if you need that.
+func (c *AMQPConsumer) Consume(queue string, concurrency int, handler AMQPMessageHandler) error {
+	if c.shutdownCtx.Err() != nil {
+		return ErrConsumerClosed
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	sub := &subscription{queue, handler, concurrency}
+	err := doConsume(c.currCtx, c.currChannel, sub)
+	if err != nil {
+		return err
+	}
+	c.subscriptions = append(c.subscriptions, sub)
+	return nil
+}
+
+func (c *AMQPConsumer) reconnectLoop() {
+	// initial state is already connected
+	for {
+		<-time.After(RetryMinDelay)
+		<-c.currCtx.Done()
+		if c.shutdownCtx.Err() != nil {
+			glog.Info("Finishing AMQP consumer reconnect loop due to shutdown")
+			return
+		}
+
+		glog.Info("Recovering AMQP consumer connection")
+		if err := c.connect(); err != nil {
+			glog.Errorf("Error connecting AMQP consumer err=%q", err)
+		}
+	}
+}
+
+func (c *AMQPConsumer) connect() error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	var (
+		ctx, cancel = context.WithCancel(context.Background())
+		closed      = make(chan *amqp.Error, 1)
+	)
+	channel, err := c.connectFn(ctx, c.amqpURI, nil, closed)
+	if err != nil {
+		cancel()
+		return err
+	}
+	for _, sub := range c.subscriptions {
+		if err := doConsume(ctx, channel, sub); err != nil {
+			cancel()
+			return fmt.Errorf("error consuming queue %q: %v", sub.queue, err)
+		}
+	}
+	go func() {
+		defer cancel()
+		select {
+		case err := <-closed:
+			glog.Infof("Channel or connection closed: %w", err)
+		case <-c.shutdownCtx.Done():
+			glog.Infof("Shutting down consumer as requested")
+		}
+	}()
+	c.currCtx, c.currChannel = ctx, channel
+	return nil
+}
+
+func doConsume(ctx context.Context, amqpch AMQPChanOps, sub *subscription) error {
+	// TODO: Create custom consumer names to be able to cancel them.
+	subs, err := amqpch.Consume(sub.queue, "", false, false, false, false, nil)
+	if err != nil {
+		return err
+	}
+	for i := 0; i < sub.concurrency; i++ {
+		go func() {
+			defer func() {
+				if rec := recover(); rec != nil {
+					glog.Errorf("Panic in background AMQP consumer: value=%v", rec)
+				}
+			}()
+			for {
+				select {
+				case msg := <-subs:
+					acker := msg.Acknowledger
+					msg.Acknowledger = nil // prevent handler from manually acking/nacking
+					err := sub.handler(msg)
+					msg.Acknowledger = acker
+					if err == nil {
+						if err := msg.Ack(false); err != nil {
+							glog.Errorf("Error ack-ing message exchange=%q, routingKey=%q, err=%q", msg.Exchange, msg.RoutingKey, err)
+						}
+						continue
+					}
+					glog.Errorf("Nacking message due to error exchange=%q, routingKey=%q, err=%q", msg.Exchange, msg.RoutingKey, err)
+					if err := msg.Nack(false, true); err != nil {
+						glog.Errorf("Error nack-ing message exchange=%q, routingKey=%q, err=%q", msg.Exchange, msg.RoutingKey, err)
+					}
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+	}
+	return nil
+}

--- a/pkg/event/interfaces.go
+++ b/pkg/event/interfaces.go
@@ -8,10 +8,6 @@ import (
 	"github.com/rabbitmq/rabbitmq-stream-go-client/pkg/stream"
 )
 
-type Producer interface {
-	Publish(ctx context.Context, key string, body interface{}, persistent bool) error
-}
-
 type (
 	BindingArgs struct {
 		Key      string
@@ -45,5 +41,9 @@ type (
 		Consume(ctx context.Context, opts ConsumeOptions, handler Handler) error
 		CheckConnection() error
 		Close() error
+	}
+
+	Producer interface {
+		Publish(ctx context.Context, key string, body interface{}, persistent bool) error
 	}
 )

--- a/pkg/event/interfaces.go
+++ b/pkg/event/interfaces.go
@@ -43,7 +43,22 @@ type (
 		Close() error
 	}
 
-	Producer interface {
+	SimpleProducer interface {
 		Publish(ctx context.Context, key string, body interface{}, persistent bool) error
+	}
+
+	AMQPProducer interface {
+		Publish(ctx context.Context, msg AMQPMessage) error
+		Shutdown(context.Context) error
+	}
+
+	AMQPConsumer interface {
+		Consume(queue string, concurrency int, handler AMQPMessageHandler) error
+		Shutdown(context.Context) error
+	}
+
+	AMQPClient interface {
+		AMQPProducer
+		AMQPConsumer
 	}
 )

--- a/pkg/event/simple_producers.go
+++ b/pkg/event/simple_producers.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
-	amqp "github.com/rabbitmq/amqp091-go"
 )
 
 func NewAMQPExchangeProducer(ctx context.Context, uri, exchange, keyNs string) (Producer, error) {
-	connectFunc := NewAMQPConnectFunc(func(channel *amqp.Channel) error {
+	connectFunc := NewAMQPConnectFunc(func(channel AMQPChanSetup) error {
 		err := channel.ExchangeDeclare(exchange, "topic", true, false, false, false, nil)
 		if err != nil {
 			return fmt.Errorf("exchange declare: %w", err)
@@ -33,7 +31,7 @@ func NewAMQPExchangeProducer(ctx context.Context, uri, exchange, keyNs string) (
 }
 
 func NewAMQPQueueProducer(ctx context.Context, uri, queue string) (Producer, error) {
-	connectFunc := NewAMQPConnectFunc(func(channel *amqp.Channel) error {
+	connectFunc := NewAMQPConnectFunc(func(channel AMQPChanSetup) error {
 		_, err := channel.QueueDeclare(queue, true, false, false, false, nil)
 		if err != nil {
 			return fmt.Errorf("queue declare: %w", err)

--- a/pkg/event/simple_producers.go
+++ b/pkg/event/simple_producers.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 )
 
-func NewAMQPExchangeProducer(ctx context.Context, uri, exchange, keyNs string) (Producer, error) {
+func NewAMQPExchangeProducer(ctx context.Context, uri, exchange, keyNs string) (SimpleProducer, error) {
 	connectFunc := NewAMQPConnectFunc(func(channel AMQPChanSetup) error {
 		err := channel.ExchangeDeclare(exchange, "topic", true, false, false, false, nil)
 		if err != nil {
@@ -30,7 +30,7 @@ func NewAMQPExchangeProducer(ctx context.Context, uri, exchange, keyNs string) (
 	}), nil
 }
 
-func NewAMQPQueueProducer(ctx context.Context, uri, queue string) (Producer, error) {
+func NewAMQPQueueProducer(ctx context.Context, uri, queue string) (SimpleProducer, error) {
 	connectFunc := NewAMQPConnectFunc(func(channel AMQPChanSetup) error {
 		_, err := channel.QueueDeclare(queue, true, false, false, false, nil)
 		if err != nil {


### PR DESCRIPTION
This will be needed by mist-api-connector for consuming messages from RabbitMQ.

Specifically, for the `CLIP_CREATED` events from the API which should be used for actually creating
the clips from the mist buffer locally (restreaming to broadcaster and etc).