### PR TITLE
Add support for mist runtime to identify binaries.

### DIFF
--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -2,6 +2,7 @@ package analyzer
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"os"
 	"os/signal"
@@ -22,7 +23,26 @@ import (
 type BuildFlags struct {
 	Version string
 }
+
+type MistOptional struct {
+	Name   string `json:"name"`
+	Help   string `json:"help"`
+	Option string `json:"option,omitempty"`
+	// Short   string `json:"short"`
+	Default string `json:"default,omitempty"`
+}
+
+type MistConfig struct {
+	Name         string         `json:"name"`
+	Description  string         `json:"desc"`
+	FriendlyName string         `json:"friendly"`
+	Optional     []MistOptional `json:"optional,omitempty"`
+	Version      string         `json:"version,omitempty"`
+}
+
 type cliFlags struct {
+	json bool
+
 	rabbitmqUri string
 	amqpUri     string
 
@@ -30,14 +50,16 @@ type cliFlags struct {
 	shardPrefixesFlag  string
 	shardPrefixes      []string
 
-	serverOpts       api.ServerOptions
+	ServerOpts       api.ServerOptions `json:"server"`
 	streamingOpts    health.StreamingOptions
 	memoryRecordsTtl time.Duration
 }
 
-func parseFlags() cliFlags {
+func parseFlags(version string) cliFlags {
 	cli := cliFlags{}
 	fs := flag.NewFlagSet("analyzer", flag.ExitOnError)
+
+	fs.BoolVar(&cli.json, "json", false, "Print application info as json")
 
 	fs.StringVar(&cli.rabbitmqUri, "rabbitmq-uri", "amqp://guest:guest@localhost:5672/livepeer", "URI for RabbitMQ server to consume from. Can be specified as a default AMQP URI which will be converted to stream protocol.")
 	fs.StringVar(&cli.amqpUri, "amqp-uri", "", "Explicit AMQP URI in case of non-default protocols/ports (optional). Must point to the same cluster as rabbitmqUri")
@@ -46,15 +68,15 @@ func parseFlags() cliFlags {
 	fs.StringVar(&cli.shardPrefixesFlag, "shard-prefixes", "", "Comma-separated list of prefixes of manifest IDs to process events from")
 
 	// Server options
-	fs.StringVar(&cli.serverOpts.Host, "host", "localhost", "Hostname to bind to")
-	fs.UintVar(&cli.serverOpts.Port, "port", 8080, "Port to listen on")
-	fs.DurationVar(&cli.serverOpts.ShutdownGracePeriod, "shutdown-grace-perod", 15*time.Second, "Grace period to wait for server shutdown before using the force")
+	fs.StringVar(&cli.ServerOpts.Host, "host", "localhost", "Hostname to bind to")
+	fs.UintVar(&cli.ServerOpts.Port, "port", 8080, "Port to listen on")
+	fs.DurationVar(&cli.ServerOpts.ShutdownGracePeriod, "shutdown-grace-perod", 15*time.Second, "Grace period to wait for server shutdown before using the force")
 	// API Handler
-	fs.StringVar(&cli.serverOpts.APIRoot, "api-root", "/data", "Root path where to bind the API to")
-	fs.BoolVar(&cli.serverOpts.Prometheus, "prometheus", false, "Whether to enable Prometheus metrics registry and expose /metrics endpoint")
-	fs.StringVar(&cli.serverOpts.AuthURL, "auth-url", "", "Endpoint for an auth server to call for both authentication and authorization of API calls")
-	fs.StringVar(&cli.serverOpts.OwnRegion, "own-region", "", "Identifier of the region where the service is running, used for triggering global request proxying")
-	fs.StringVar(&cli.serverOpts.RegionalHostFormat, "regional-host-format", "localhost", "Format to build regional URL for proxying to other regions. Should contain 1 %s directive where the region will be replaced (e.g. %s.livepeer.monster)")
+	fs.StringVar(&cli.ServerOpts.APIRoot, "api-root", "/data", "Root path where to bind the API to")
+	fs.BoolVar(&cli.ServerOpts.Prometheus, "prometheus", false, "Whether to enable Prometheus metrics registry and expose /metrics endpoint")
+	fs.StringVar(&cli.ServerOpts.AuthURL, "auth-url", "", "Endpoint for an auth server to call for both authentication and authorization of API calls")
+	fs.StringVar(&cli.ServerOpts.OwnRegion, "own-region", "", "Identifier of the region where the service is running, used for triggering global request proxying")
+	fs.StringVar(&cli.ServerOpts.RegionalHostFormat, "regional-host-format", "localhost", "Format to build regional URL for proxying to other regions. Should contain 1 %s directive where the region will be replaced (e.g. %s.livepeer.monster)")
 
 	// Streaming options
 	fs.StringVar(&cli.streamingOpts.Stream, "rabbitmq-stream-name", "lp_stream_health_v0", "Name of RabbitMQ stream to create and consume from")
@@ -84,12 +106,33 @@ func parseFlags() cliFlags {
 	if cli.shardPrefixesFlag != "" {
 		cli.shardPrefixes = strings.Split(cli.shardPrefixesFlag, ",")
 	}
+
+	if cli.json {
+		data := &MistConfig{
+			Name:         "LivepeerAnalyzer",
+			Version:      version,
+			Description:  "",
+			FriendlyName: "Livepeer Analyzer",
+			Optional:     []MistOptional{},
+		}
+		fs.VisitAll(func(f *flag.Flag) {
+			data.Optional = append(data.Optional, MistOptional{
+				Name:    f.Name,
+				Help:    f.Usage,
+				Default: f.DefValue,
+			})
+		})
+		b, _ := json.Marshal(data)
+		os.Stdout.Write(b)
+		os.Exit(255)
+	}
+
 	return cli
 }
 
 func Run(build BuildFlags) {
-	cli := parseFlags()
-	cli.serverOpts.APIHandlerOptions.ServerName = "analyzer/" + build.Version
+	cli := parseFlags(build.Version)
+	cli.ServerOpts.APIHandlerOptions.ServerName = "analyzer/" + build.Version
 
 	glog.Infof("Stream health care system starting up... version=%q", build.Version)
 	ctx := contextUntilSignal(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -115,7 +158,7 @@ func Run(build BuildFlags) {
 	}
 
 	glog.Info("Starting server...")
-	err = api.ListenAndServe(ctx, cli.serverOpts, healthcore)
+	err = api.ListenAndServe(ctx, cli.ServerOpts, healthcore)
 	if err != nil {
 		glog.Fatalf("Error starting api server. err=%q", err)
 	}

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -15,7 +15,7 @@ import (
 	"github.com/livepeer/livepeer-data/health"
 	"github.com/livepeer/livepeer-data/health/reducers"
 	"github.com/livepeer/livepeer-data/pkg/event"
-	"github.com/livepeer/livepeer-data/pkg/mist-connector"
+	"github.com/livepeer/livepeer-data/pkg/mistconnector"
 	"github.com/peterbourgon/ff"
 )
 

--- a/pkg/mist-connector/main.go
+++ b/pkg/mist-connector/main.go
@@ -31,7 +31,7 @@ func isIntType(value string) bool {
 	return false
 }
 
-func PrintMistConfigJson(name string, description string, friendlyName string, version string, flagSet *flag.FlagSet) {
+func PrintMistConfigJson(name, description, friendlyName, version string, flagSet *flag.FlagSet) {
 	data := MistConfig{
 		Name:         name,
 		Version:      version,

--- a/pkg/mist-connector/main.go
+++ b/pkg/mist-connector/main.go
@@ -1,0 +1,60 @@
+package mistconnector
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+type MistOptional struct {
+	Name    string `json:"name"`
+	Help    string `json:"help"`
+	Option  string `json:"option,omitempty"`
+	Default string `json:"default,omitempty"`
+	Type    string `json:"type,omitempty"`
+}
+
+type MistConfig struct {
+	Name         string                  `json:"name"`
+	Description  string                  `json:"desc"`
+	FriendlyName string                  `json:"friendly"`
+	Optional     map[string]MistOptional `json:"optional,omitempty"`
+	Version      string                  `json:"version,omitempty"`
+}
+
+func isIntType(value string) bool {
+	if _, err := strconv.Atoi(value); err == nil {
+		return true
+	}
+	return false
+}
+
+func PrintMistConfigJson(name string, description string, friendlyName string, version string, flagSet *flag.FlagSet) {
+	data := MistConfig{
+		Name:         name,
+		Version:      version,
+		Description:  description,
+		FriendlyName: friendlyName,
+		Optional:     make(map[string]MistOptional),
+	}
+	flagSet.VisitAll(func(f *flag.Flag) {
+		var flagType string = ""
+		if len(f.DefValue) > 0 {
+			flagType = "str"
+		}
+		if isIntType(f.DefValue) {
+			flagType = "uint"
+		}
+		data.Optional[f.Name] = MistOptional{
+			Name:    f.Name,
+			Help:    f.Usage,
+			Option:  fmt.Sprintf("-%s", f.Name),
+			Default: f.DefValue,
+			Type:    flagType,
+		}
+	})
+	b, _ := json.Marshal(data)
+	os.Stdout.Write(b)
+}

--- a/pkg/mistconnector/main.go
+++ b/pkg/mistconnector/main.go
@@ -47,9 +47,8 @@ func PrintMistConfigJson(name, description, friendlyName, version string, flagSe
 		Optional:     make(map[string]MistOptional),
 	}
 	flagSet.VisitAll(func(f *flag.Flag) {
-		var flagType string = ""
+		var flagType string = "str"
 		if len(f.DefValue) > 0 {
-			flagType = "str"
 			if isIntType(f.DefValue) {
 				flagType = "uint"
 			}

--- a/pkg/mistconnector/main.go
+++ b/pkg/mistconnector/main.go
@@ -31,6 +31,13 @@ func isIntType(value string) bool {
 	return false
 }
 
+func isBoolType(value string) bool {
+	if _, err := strconv.ParseBool(value); err == nil {
+		return true
+	}
+	return false
+}
+
 func PrintMistConfigJson(name, description, friendlyName, version string, flagSet *flag.FlagSet) {
 	data := MistConfig{
 		Name:         name,
@@ -43,9 +50,12 @@ func PrintMistConfigJson(name, description, friendlyName, version string, flagSe
 		var flagType string = ""
 		if len(f.DefValue) > 0 {
 			flagType = "str"
-		}
-		if isIntType(f.DefValue) {
-			flagType = "uint"
+			if isIntType(f.DefValue) {
+				flagType = "uint"
+			}
+			if isBoolType(f.DefValue) {
+				flagType = ""
+			}
 		}
 		data.Optional[f.Name] = MistOptional{
 			Name:    f.Name,


### PR DESCRIPTION
Related to #35.

This would allow the built binary to be added as a mist capability.

The flag generates output as the following (click "Details" to expand):
<details>

```
{
  "name": "LivepeerAnalyzer",
  "desc": "Stream health data analyzer service for aggregated reporting of running streams status",
  "friendly": "Livepeer Analyzer",
  "optional": {
    "amqp-uri": {
      "name": "amqp-uri",
      "help": "Explicit AMQP URI in case of non-default protocols/ports (optional). Must point to the same cluster as rabbitmqUri",
      "option": "-amqp-uri"
    },
    "api-root": {
      "name": "api-root",
      "help": "Root path where to bind the API to",
      "option": "-api-root",
      "default": "/data",
      "type": "str"
    },
    "auth-url": {
      "name": "auth-url",
      "help": "Endpoint for an auth server to call for both authentication and authorization of API calls",
      "option": "-auth-url"
    },
    "config": {
      "name": "config",
      "help": "config file (optional)",
      "option": "-config"
    },
    "consumer-name": {
      "name": "consumer-name",
      "help": "Consumer name to use when consuming stream (default \"analyzer-${hostname}\")",
      "option": "-consumer-name"
    },
    "golivepeer-exchange": {
      "name": "golivepeer-exchange",
      "help": "Name of RabbitMQ exchange to bind the stream to on creation",
      "option": "-golivepeer-exchange",
      "default": "lp_golivepeer_metadata",
      "type": "str"
    },
    "host": {
      "name": "host",
      "help": "Hostname to bind to",
      "option": "-host",
      "default": "localhost",
      "type": "str"
    },
    "j": {
      "name": "j",
      "help": "Print application info as json",
      "option": "-j",
      "default": "false",
      "type": "str"
    },
    "memory-records-ttl": {
      "name": "memory-records-ttl",
      "help": "How long to keep data records in memory about inactive streams",
      "option": "-memory-records-ttl",
      "default": "24h0m0s",
      "type": "str"
    },
    "own-region": {
      "name": "own-region",
      "help": "Identifier of the region where the service is running, used for triggering global request proxying",
      "option": "-own-region"
    },
    "port": {
      "name": "port",
      "help": "Port to listen on",
      "option": "-port",
      "default": "8080",
      "type": "uint"
    },
    "prometheus": {
      "name": "prometheus",
      "help": "Whether to enable Prometheus metrics registry and expose /metrics endpoint",
      "option": "-prometheus",
      "default": "false",
      "type": "str"
    },
    "rabbitmq-stream-name": {
      "name": "rabbitmq-stream-name",
      "help": "Name of RabbitMQ stream to create and consume from",
      "option": "-rabbitmq-stream-name",
      "default": "lp_stream_health_v0",
      "type": "str"
    },
    "rabbitmq-uri": {
      "name": "rabbitmq-uri",
      "help": "URI for RabbitMQ server to consume from. Can be specified as a default AMQP URI which will be converted to stream protocol.",
      "option": "-rabbitmq-uri",
      "default": "amqp://guest:guest@localhost:5672/livepeer",
      "type": "str"
    },
    "regional-host-format": {
      "name": "regional-host-format",
      "help": "Format to build regional URL for proxying to other regions. Should contain 1 %s directive where the region will be replaced (e.g. %s.livepeer.monster)",
      "option": "-regional-host-format",
      "default": "localhost",
      "type": "str"
    },
    "shard-prefixes": {
      "name": "shard-prefixes",
      "help": "Comma-separated list of prefixes of manifest IDs to process events from",
      "option": "-shard-prefixes"
    },
    "shutdown-grace-perod": {
      "name": "shutdown-grace-perod",
      "help": "Grace period to wait for server shutdown before using the force",
      "option": "-shutdown-grace-perod",
      "default": "15s",
      "type": "str"
    },
    "stream-max-age": {
      "name": "stream-max-age",
      "help": "When creating a new stream, config for max age of stored events",
      "option": "-stream-max-age",
      "default": "720h0m0s",
      "type": "str"
    },
    "stream-max-length": {
      "name": "stream-max-length",
      "help": "When creating a new stream, config for max total storage size",
      "option": "-stream-max-length",
      "default": "50gb",
      "type": "str"
    },
    "stream-max-segment-size": {
      "name": "stream-max-segment-size",
      "help": "When creating a new stream, config for max stream segment size in storage",
      "option": "-stream-max-segment-size",
      "default": "500mb",
      "type": "str"
    },
    "v": {
      "name": "v",
      "help": "Log verbosity {0-10}",
      "option": "-v",
      "default": "0",
      "type": "uint"
    }
  },
  "version": "v0.4.7-4-g56fae98-dirty"
}

```

</details>