### PR TITLE
pkg/mistconnector: Fix issue with `0` being treated as boolean type.

### DIFF
--- a/pkg/mistconnector/main.go
+++ b/pkg/mistconnector/main.go
@@ -51,8 +51,7 @@ func PrintMistConfigJson(name, description, friendlyName, version string, flagSe
 		if len(f.DefValue) > 0 {
 			if isIntType(f.DefValue) {
 				flagType = "uint"
-			}
-			if isBoolType(f.DefValue) {
+			} else if isBoolType(f.DefValue) {
 				flagType = ""
 			}
 		}


### PR DESCRIPTION
A default value of `0` for a flag validates the boolean flag check for
integer type fields. The boolean check will now occur only if integer
check fails.