### PR TITLE
analyzer: Reconnect stream consumer after some time without messages

### DIFF
--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -68,6 +68,7 @@ func parseFlags(version string) cliFlags {
 	fs.StringVar(&cli.streamingOpts.MaxLengthBytes, "stream-max-length", "50gb", "When creating a new stream, config for max total storage size")
 	fs.StringVar(&cli.streamingOpts.MaxSegmentSizeBytes, "stream-max-segment-size", "500mb", "When creating a new stream, config for max stream segment size in storage")
 	fs.DurationVar(&cli.streamingOpts.MaxAge, "stream-max-age", 30*24*time.Hour, `When creating a new stream, config for max age of stored events`)
+	fs.DurationVar(&cli.streamingOpts.ReconnectThreshold, "stream-consumer-reconnect-threshold", 3*time.Minute, "The time that the client will wait without receiving any messages before it restarts the stream consumer out of caution")
 	fs.DurationVar(&cli.memoryRecordsTtl, "memory-records-ttl", 24*time.Hour, `How long to keep data records in memory about inactive streams`)
 
 	flag.Set("logtostderr", "true")

--- a/health/core.go
+++ b/health/core.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	eventSubscriptionBufSize = 10
-	processLogSampleRate     = 0.04
+	eventSubscriptionBufSize         = 10
+	processLogSampleRate             = 0.04
+	streamConsumerReconnectThreshold = 3 * time.Minute
 )
 
 var (
@@ -268,8 +269,9 @@ func (c *Core) consumeOptions() (event.ConsumeOptions, error) {
 			StreamOptions: *streamOpts,
 			Bindings:      bindings,
 		},
-		ConsumerOptions: event.NewConsumerOptions(opts.ConsumerName, event.TimestampOffset(startTime)),
-		MemorizeOffset:  true,
+		ConsumerOptions:    event.NewConsumerOptions(opts.ConsumerName, event.TimestampOffset(startTime)),
+		MemorizeOffset:     true,
+		ReconnectThreshold: streamConsumerReconnectThreshold,
 	}, nil
 }
 

--- a/health/core.go
+++ b/health/core.go
@@ -17,9 +17,8 @@ import (
 )
 
 const (
-	eventSubscriptionBufSize         = 10
-	processLogSampleRate             = 0.04
-	streamConsumerReconnectThreshold = 3 * time.Minute
+	eventSubscriptionBufSize = 10
+	processLogSampleRate     = 0.04
 )
 
 var (
@@ -53,6 +52,7 @@ type StreamingOptions struct {
 	Stream, ConsumerName string
 
 	event.RawStreamOptions
+	ReconnectThreshold time.Duration
 }
 
 type CoreOptions struct {
@@ -271,7 +271,7 @@ func (c *Core) consumeOptions() (event.ConsumeOptions, error) {
 		},
 		ConsumerOptions:    event.NewConsumerOptions(opts.ConsumerName, event.TimestampOffset(startTime)),
 		MemorizeOffset:     true,
-		ReconnectThreshold: streamConsumerReconnectThreshold,
+		ReconnectThreshold: opts.ReconnectThreshold,
 	}, nil
 }
 

--- a/pkg/event/interfaces.go
+++ b/pkg/event/interfaces.go
@@ -30,7 +30,7 @@ type (
 		MemorizeOffset bool
 		// ReconnectThreshold is the time that the client will wait without
 		// receiving any messages before it restarts the stream consumer out of
-		// caution. The default is 10 minutes.
+		// caution. If not specified no automatic reconnection will be made.
 		ReconnectThreshold time.Duration
 	}
 

--- a/pkg/event/interfaces.go
+++ b/pkg/event/interfaces.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"context"
+	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 	streamAmqp "github.com/rabbitmq/rabbitmq-stream-go-client/pkg/amqp"
@@ -24,7 +25,13 @@ type (
 		Stream string
 		*StreamOptions
 		*stream.ConsumerOptions
+		// Whether to memorize the message offset in the stream and use it on
+		// re-connections to continue from the last read message.
 		MemorizeOffset bool
+		// ReconnectThreshold is the time that the client will wait without
+		// receiving any messages before it restarts the stream consumer out of
+		// caution. The default is 10 minutes.
+		ReconnectThreshold time.Duration
 	}
 
 	StreamMessage struct {


### PR DESCRIPTION
This is to improve reliability of the analyzer, by detecting if we get no messages from rabbimtq
and restarting the consumer manually to fix it if so. This is because we've noticed that the amqp
stream consumer lib fails to detect when RabbitMQ clusters are disconnected and just stays
there for a long time without receiving any messages until we manually restart the analyzers.

This fixes that by reconnecting the stream consumer every 3 minutes if no messages are received.