### PR TITLE
analyzer: Fail healtcheck after some time without messages

### DIFF
--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -68,7 +68,7 @@ func parseFlags(version string) cliFlags {
 	fs.StringVar(&cli.streamingOpts.MaxLengthBytes, "stream-max-length", "50gb", "When creating a new stream, config for max total storage size")
 	fs.StringVar(&cli.streamingOpts.MaxSegmentSizeBytes, "stream-max-segment-size", "500mb", "When creating a new stream, config for max stream segment size in storage")
 	fs.DurationVar(&cli.streamingOpts.MaxAge, "stream-max-age", 30*24*time.Hour, `When creating a new stream, config for max age of stored events`)
-	fs.DurationVar(&cli.streamingOpts.EventFlowSilenceTolerance, "event-flow-silence-tolerance", 10*time.Minute, "The time to tolerate getting zero messages in the stream before crashing the process to force a full reset")
+	fs.DurationVar(&cli.streamingOpts.EventFlowSilenceTolerance, "event-flow-silence-tolerance", 10*time.Minute, "The time to tolerate getting zero messages in the stream before giving an error on the service healthcheck")
 	fs.DurationVar(&cli.memoryRecordsTtl, "memory-records-ttl", 24*time.Hour, `How long to keep data records in memory about inactive streams`)
 
 	flag.Set("logtostderr", "true")

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -68,6 +68,7 @@ func parseFlags(version string) cliFlags {
 	fs.StringVar(&cli.streamingOpts.MaxLengthBytes, "stream-max-length", "50gb", "When creating a new stream, config for max total storage size")
 	fs.StringVar(&cli.streamingOpts.MaxSegmentSizeBytes, "stream-max-segment-size", "500mb", "When creating a new stream, config for max stream segment size in storage")
 	fs.DurationVar(&cli.streamingOpts.MaxAge, "stream-max-age", 30*24*time.Hour, `When creating a new stream, config for max age of stored events`)
+	fs.DurationVar(&cli.streamingOpts.EventFlowSilenceTolerance, "event-flow-silence-tolerance", 10*time.Minute, "The time to tolerate getting zero messages in the stream before crashing the process to force a full reset")
 	fs.DurationVar(&cli.memoryRecordsTtl, "memory-records-ttl", 24*time.Hour, `How long to keep data records in memory about inactive streams`)
 
 	flag.Set("logtostderr", "true")

--- a/health/core.go
+++ b/health/core.go
@@ -52,6 +52,12 @@ type StreamingOptions struct {
 	Stream, ConsumerName string
 
 	event.RawStreamOptions
+
+	// EventFlowSilenceTolerance determines the amount of time to tolerate zero
+	// messages in the stream before crashing the process to force a full reset.
+	// This is a workaround for a bug in the rabbitmq streams client in which it
+	// freezes when the stream has leader election issues in a clustered setup.
+	EventFlowSilenceTolerance time.Duration
 }
 
 type CoreOptions struct {

--- a/health/core.go
+++ b/health/core.go
@@ -74,8 +74,8 @@ type Core struct {
 	reducer        Reducer
 	conditionTypes []data.ConditionType
 
-	storage              RecordStorage
-	lastEventReceiveTime time.Time
+	storage     RecordStorage
+	lastEventTs time.Time
 }
 
 func NewCore(opts CoreOptions, consumer event.StreamConsumer, reducer Reducer) *Core {
@@ -93,8 +93,8 @@ func (c *Core) IsHealthy() bool {
 		glog.Warningf("Health core is unhealthy. reason=consumerErr consumerErr=%q", err)
 		return false
 	}
-	if tol := c.opts.Streaming.EventFlowSilenceTolerance; tol > 0 && time.Since(c.lastEventReceiveTime) > tol {
-		glog.Warningf("Health core is unhealthy. reason=noEvents lastEventReceiveTime=%s, tolerance=%s", c.lastEventReceiveTime, tol)
+	if tol := c.opts.Streaming.EventFlowSilenceTolerance; tol > 0 && time.Since(c.lastEventTs) > tol {
+		glog.Warningf("Health core is unhealthy. reason=noEvents lastEventTs=%s, tolerance=%s", c.lastEventTs, tol)
 		return false
 	}
 	return true
@@ -146,9 +146,8 @@ func (c *Core) HandleMessage(msg event.StreamMessage) {
 }
 
 func (c *Core) handleSingleEvent(evt data.Event) {
-	c.lastEventReceiveTime = time.Now()
-
 	streamID, ts := evt.StreamID(), evt.Timestamp()
+	c.lastEventTs = ts
 	record := c.storage.GetOrCreate(streamID, c.conditionTypes)
 
 	record.RLock()

--- a/health/core.go
+++ b/health/core.go
@@ -54,7 +54,7 @@ type StreamingOptions struct {
 	event.RawStreamOptions
 
 	// EventFlowSilenceTolerance determines the amount of time to tolerate zero
-	// messages in the stream before crashing the process to force a full reset.
+	// messages in the stream before giving an error on the service healthcheck.
 	// This is a workaround for a bug in the rabbitmq streams client in which it
 	// freezes when the stream has leader election issues in a clustered setup.
 	EventFlowSilenceTolerance time.Duration

--- a/pkg/event/interfaces.go
+++ b/pkg/event/interfaces.go
@@ -24,6 +24,8 @@ type (
 		Stream string
 		*StreamOptions
 		*stream.ConsumerOptions
+		// Whether to memorize the message offset in the stream and use it on
+		// re-connections to continue from the last read message.
 		MemorizeOffset bool
 	}
 


### PR DESCRIPTION
This is to improve reliability of the analyzer, by detecting if we get no messages from RabbitMQ
and starting to respond with an error on the service healthcheck. This is because we've noticed that 
the RabbitMQ stream consumer lib fails to detect when RabbitMQ clusters are disconnected and
just stays there for a long time without receiving any messages until we manually restart the analyzers.

This is very similar to #49 but with a much simpler logic. Instead of attempting to heal the client internally,
we'll just start responding with an error on the healthcheck and let Kubernetes restart the container
through a liveness probe.