### PR TITLE
api: Add authorization to viewership API

### DIFF
--- a/api/authorization.go
+++ b/api/authorization.go
@@ -48,7 +48,7 @@ func authorization(authUrl string) middleware {
 			respondError(rw, http.StatusInternalServerError, err)
 			return
 		}
-		req.Header.Set("X-Original-Uri", req.URL.String())
+		req.Header.Set("X-Original-Uri", r.URL.String())
 		if streamID := apiParam(r, streamIDParam); streamID != "" {
 			req.Header.Set("X-Livepeer-Stream-Id", streamID)
 		} else if assetID := apiParam(r, assetIDParam); assetID != "" {

--- a/api/authorization.go
+++ b/api/authorization.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -56,12 +55,6 @@ func authorization(authUrl string) middleware {
 			authReq.Header.Set("X-Livepeer-Asset-Id", assetID)
 		}
 		copyHeaders(authorizationHeaders, r.Header, authReq.Header)
-
-		hs, _ := json.Marshal(authReq.Header)
-		glog.Infof("Performing auth request: %s %s headers=%s", authReq.Method, authReq.URL, hs)
-		inHs, _ := json.Marshal(r.Header)
-		glog.Infof("auth: From request: %s %s headers=%s", r.Method, r.URL, inHs)
-
 		authRes, err := httpClient.Do(authReq)
 		if err != nil {
 			respondError(rw, http.StatusInternalServerError, fmt.Errorf("error authorizing request: %w", err))

--- a/api/authorization.go
+++ b/api/authorization.go
@@ -34,14 +34,17 @@ func authorization(authUrl string) middleware {
 		ctx, cancel := context.WithTimeout(r.Context(), authTimeout)
 		defer cancel()
 
-		status := getStreamStatus(r)
 		req, err := http.NewRequestWithContext(ctx, r.Method, authUrl, nil)
 		if err != nil {
 			respondError(rw, http.StatusInternalServerError, err)
 			return
 		}
 		req.Header.Set("X-Original-Uri", req.URL.String())
-		req.Header.Set("X-Livepeer-Stream-Id", status.ID)
+		if streamID := apiParam(r, streamIDParam); streamID != "" {
+			req.Header.Set("X-Livepeer-Stream-Id", streamID)
+		} else if assetID := apiParam(r, assetIDParam); assetID != "" {
+			req.Header.Set("X-Livepeer-Asset-Id", assetID)
+		}
 		for _, header := range authorizationHeaders {
 			req.Header[header] = r.Header[header]
 		}

--- a/api/authorization.go
+++ b/api/authorization.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -55,6 +56,12 @@ func authorization(authUrl string) middleware {
 			authReq.Header.Set("X-Livepeer-Asset-Id", assetID)
 		}
 		copyHeaders(authorizationHeaders, r.Header, authReq.Header)
+
+		hs, _ := json.Marshal(authReq.Header)
+		glog.Infof("Performing auth request: %s %s headers=%s", authReq.Method, authReq.URL, hs)
+		inHs, _ := json.Marshal(r.Header)
+		glog.Infof("auth: From request: %s %s headers=%s", r.Method, r.URL, inHs)
+
 		authRes, err := httpClient.Do(authReq)
 		if err != nil {
 			respondError(rw, http.StatusInternalServerError, fmt.Errorf("error authorizing request: %w", err))

--- a/api/authorization.go
+++ b/api/authorization.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	authorizationHeaders = []string{"Authorization", "Cookie"}
+	authorizationHeaders = []string{"Authorization", "Cookie", "Origin"}
 	authTimeout          = 3 * time.Second
 
 	authRequestDuration = metrics.Factory.NewSummaryVec(

--- a/api/errors.go
+++ b/api/errors.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/livepeer/livepeer-data/health"
+	"github.com/livepeer/livepeer-data/views"
 )
 
 type errorResponse struct {
@@ -18,7 +19,9 @@ func respondError(rw http.ResponseWriter, defaultStatus int, errs ...error) {
 	response := errorResponse{}
 	for _, err := range errs {
 		response.Errors = append(response.Errors, err.Error())
-		if errors.Is(err, health.ErrStreamNotFound) || errors.Is(err, health.ErrEventNotFound) {
+		if errors.Is(err, health.ErrStreamNotFound) ||
+			errors.Is(err, health.ErrEventNotFound) ||
+			errors.Is(err, views.ErrAssetNotFound) {
 			status = http.StatusNotFound
 		}
 	}

--- a/api/handler.go
+++ b/api/handler.go
@@ -93,6 +93,10 @@ func (h *apiHandler) cors() middleware {
 		}
 		rw.Header().Set("Access-Control-Allow-Origin", "*")
 		rw.Header().Set("Access-Control-Allow-Headers", "*")
+		if origin := r.Header.Get("Origin"); origin != "" {
+			rw.Header().Set("Access-Control-Allow-Origin", origin)
+			rw.Header().Set("Access-Control-Allow-Credentials", "true")
+		}
 		next.ServeHTTP(rw, r)
 	})
 }

--- a/api/handler.go
+++ b/api/handler.go
@@ -74,10 +74,13 @@ func addStreamHealthHandlers(router *httprouter.Router, handler *apiHandler) {
 
 func addViewershipHandlers(router *httprouter.Router, handler *apiHandler) {
 	opts := handler.opts
-	// TODO: Add authorization to views API
+	middlewares := []middleware{}
+	if opts.AuthURL != "" {
+		middlewares = append(middlewares, authorization(opts.AuthURL))
+	}
 	addApiHandler := func(apiPath, name string, handler http.HandlerFunc) {
 		fullPath := path.Join(opts.APIRoot, "/views/:"+assetIDParam, apiPath)
-		fullHandler := prepareHandlerFunc(name, opts.Prometheus, handler)
+		fullHandler := prepareHandlerFunc(name, opts.Prometheus, handler, middlewares...)
 		router.Handler("GET", fullPath, fullHandler)
 	}
 	addApiHandler("/total", "get_total_views", handler.getTotalViews)

--- a/api/streamStatus.go
+++ b/api/streamStatus.go
@@ -14,7 +14,7 @@ const (
 	streamStatusKey contextKey = iota
 )
 
-func streamStatus(healthcore *health.Core, streamIDParam string) middleware {
+func streamStatus(healthcore *health.Core) middleware {
 	return inlineMiddleware(func(rw http.ResponseWriter, r *http.Request, next http.Handler) {
 		streamID := apiParam(r, streamIDParam)
 		if streamID == "" {

--- a/views/client.go
+++ b/views/client.go
@@ -13,6 +13,8 @@ import (
 	"github.com/prometheus/common/model"
 )
 
+var ErrAssetNotFound = errors.New("asset not found")
+
 type TotalViews struct {
 	ID         string `json:"id"`
 	StartViews int64  `json:"startViews"`
@@ -44,7 +46,7 @@ func (c *Client) GetTotalViews(ctx context.Context, id string) ([]TotalViews, er
 		asset, err = c.lp.GetAssetByPlaybackID(id, false)
 	}
 	if errors.Is(err, livepeer.ErrNotExists) {
-		return nil, errors.New("asset not found")
+		return nil, ErrAssetNotFound
 	} else if err != nil {
 		return nil, fmt.Errorf("error getting asset: %w", err)
 	}

--- a/views/client.go
+++ b/views/client.go
@@ -43,9 +43,6 @@ func NewClient(opts ClientOptions) (*Client, error) {
 func (c *Client) GetTotalViews(ctx context.Context, id string) ([]TotalViews, error) {
 	asset, err := c.lp.GetAsset(id)
 	if errors.Is(err, livepeer.ErrNotExists) {
-		asset, err = c.lp.GetAssetByPlaybackID(id, false)
-	}
-	if errors.Is(err, livepeer.ErrNotExists) {
 		return nil, ErrAssetNotFound
 	} else if err != nil {
 		return nil, fmt.Errorf("error getting asset: %w", err)


### PR DESCRIPTION
This is to add proper authorization to the viewership API. Meaning we do the same scheme as for 
stream health on the `/views` API.

This means calling the Studio API with the `Authorization` header for it to authorize the given request.
We also need to provide the ID of the asset being accessed, since Studio API shouldn't handle parsing
our own API paths (although it will contain our API format to allow CORS on it).

Either way, the other relevant change is that now you can't call the playback API with the asset playback ID.
Need to use the ID instead. This was to simplify the whole authorization logic. Since this API is authenticated
now, I believe this is fine.

We will need to rethink it when we want an actually public API tho, since only the playback ID may be available
in that context.

This goes together with https://github.com/livepeer/studio/pull/1279

This implements livepeer/studio#1280