### PR TITLE
build.yaml: Add GCP upload job to workflow

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: daily
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-          cache-dependecy-path: go.sum
+          cache-dependency-path: go.sum
 
       - name: Export OS and platform env
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         platform:
           - name: windows

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,30 +10,22 @@ on:
       - "v*"
 
 jobs:
-  # The job id is mostly the runner OS
-  linux:
+  build:
     strategy:
       matrix:
         platform:
-          - windows
-          - linux
+          - name: windows
+            os: ubuntu-20.04
+          - name: linux
+            os: ubuntu-20.04
+          - name: darwin
+            os: macos-11
         arch:
           - arm64
           - amd64
-    name: Build binaries for ${{ matrix.platform }} platform (${{ matrix.arch }})
-    runs-on: ubuntu-20.04
+    name: Build binaries for ${{ matrix.platform.name }}-${{ matrix.arch }}
+    runs-on: ${{ matrix.platform.os }}
     steps:
-      - name: Export OS and platform env
-        run: |
-          echo "GOOS=${{ matrix.platform }}" >> $GITHUB_ENV
-          echo "GOARCH=${{ matrix.arch }}" >> $GITHUB_ENV
-
-      - name: Set up go
-        id: go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.17
-
       - name: Check out code
         uses: actions/checkout@v3
         with:
@@ -42,25 +34,45 @@ jobs:
           # for ref value discussion
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Restore cache
-        id: cache-go-mod
-        uses: actions/cache@v3
+      - name: Set up go
+        id: go
+        uses: actions/setup-go@v3
         with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-${{ matrix.arch }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.arch }}-go-
+          go-version-file: go.mod
+          cache: true
+          cache-dependecy-path: go.sum
+
+      - name: Export OS and platform env
+        run: |
+          echo "GOOS=${{ matrix.platform }}" >> $GITHUB_ENV
+          echo "GOARCH=${{ matrix.arch }}" >> $GITHUB_ENV
 
       - name: Download dependencies
-        if: steps.cache-go-mod.outputs.cache-hit != 'true'
+        if: steps.go.outputs.cache-hit != 'true'
         run: go mod download
 
       - name: Build
         run: |
-          mkdir -p "build/" "releases/"
+          mkdir -p build/ releases/
           make
+
+      - uses: actions-ecosystem/action-regex-match@v2
+        id: match-tag
+        with:
+          text: ${{ github.ref_name }}
+          regex: '^(master|main|v[0-9]+\.\d+\.\d+)$'
+
+      - name: Codesign and notarize binaries
+        if: steps.match-tag.outputs.match != '' && matrix.platform.name == 'darwin'
+        uses: livepeer/action-gh-codesign-apple@latest
+        with:
+          developer-certificate-id: ${{ secrets.CI_MACOS_CERTIFICATE_ID }}
+          developer-certificate-base64: ${{ secrets.CI_MACOS_CERTIFICATE_BASE64 }}
+          developer-certificate-password: ${{ secrets.CI_MACOS_CERTIFICATE_PASSWORD }}
+          app-notarization-email: ${{ secrets.CI_MACOS_NOTARIZATION_USER }}
+          app-notarization-password: ${{ secrets.CI_MACOS_NOTARIZATION_PASSWORD }}
+          binary-path: "build/livepeer-analyzer"
+          app-bundle-id: "org.livepeer.analyzer"
 
       - name: Archive binaries for windows
         if: matrix.platform == 'windows'
@@ -69,8 +81,8 @@ jobs:
           mv analyzer.exe livepeer-analyzer.exe
           zip -9q "../releases/livepeer-analyzer-${GOOS}-${GOARCH}.zip" livepeer-analyzer.exe
 
-      - name: Archive binaries for linux
-        if: matrix.platform == 'linux'
+      - name: Archive binaries for not windows
+        if: matrix.platform != 'windows'
         run: |
           cd build/
           mv analyzer livepeer-analyzer
@@ -82,141 +94,55 @@ jobs:
           name: release-artifacts
           path: releases/
 
-  macos:
-    strategy:
-      matrix:
-        arch:
-          - arm64
-          - amd64
-    name: Build binaries for macOS platform
-    runs-on: macos-11
+  upload:
+    name: Upload artifacts to google bucket
+    permissions:
+      contents: "read"
+      id-token: "write"
+    runs-on: ubuntu-latest
+    needs:
+      - build
     steps:
-      - name: Set up go
-        id: go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.17
-
-      - name: Check out code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          # Check https://github.com/livepeer/go-livepeer/pull/1891
-          # for ref value discussion
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Restore cache
-        id: cache-go-mod
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-${{ matrix.arch }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.arch }}-go-
-
-      - name: Download dependencies
-        if: steps.cache-go-mod.outputs.cache-hit != 'true'
-        run: go mod download
-
-      - name: Build
-        run: |
-          mkdir -p "build/" "releases/"
-          GOARCH="${{ matrix.arch }}" make
-          cd build/
-          mv analyzer livepeer-analyzer
-
-      - uses: actions-ecosystem/action-regex-match@v2
-        id: match-tag
-        with:
-          text: ${{ github.ref_name }}
-          regex: '^(master|main|v[0-9]+\.\d+\.\d+)$'
-
-      - name: Codesign and notarize binaries
-        if: ${{ steps.match-tag.outputs.match != '' }}
-        uses: livepeer/action-gh-codesign-apple@latest
-        with:
-          developer-certificate-id: ${{ secrets.CI_MACOS_CERTIFICATE_ID }}
-          developer-certificate-base64: ${{ secrets.CI_MACOS_CERTIFICATE_BASE64 }}
-          developer-certificate-password: ${{ secrets.CI_MACOS_CERTIFICATE_PASSWORD }}
-          app-notarization-email: ${{ secrets.CI_MACOS_NOTARIZATION_USER }}
-          app-notarization-password: ${{ secrets.CI_MACOS_NOTARIZATION_PASSWORD }}
-          binary-path: "build/livepeer-analyzer"
-          app-bundle-id: "org.livepeer.analyzer"
-
-      - name: Archive signed binary
-        run: |
-          cd build/
-          tar -czf "../releases/livepeer-analyzer-darwin-${{ matrix.arch }}.tar.gz" livepeer-analyzer
-
-      - name: Upload artifacts for cutting release
-        uses: actions/upload-artifact@master
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
         with:
           name: release-artifacts
           path: releases/
 
-  # Disabled windows build job, to reduce time consumed overall
-  # windows:
-  #   defaults:
-  #     run:
-  #       shell: msys2 {0}
-  #   strategy:
-  #     matrix:
-  #       arch:
-  #         - arm64
-  #         - amd64
-  #   name: Build binaries for windows platform
-  #   runs-on: windows-2022
-  #   steps:
-  #     - uses: msys2/setup-msys2@v2
-  #       with:
-  #         update: true
-  #         install: >-
-  #           mingw-w64-x86_64-binutils
-  #           mingw-w64-x86_64-gcc
-  #           mingw-w64-x86_64-go
-  #           git
-  #           make
-  #           autoconf
-  #           automake
-  #           patch
-  #           libtool
-  #           texinfo
-  #           gtk-doc
-  #           zip
+      - name: Generate sha256 checksum and gpg signatures for release artifacts
+        uses: livepeer/action-gh-checksum-and-gpg-sign@latest
+        with:
+          artifacts-dir: releases
+          release-name: ${{ github.ref_type == 'tag' && github.ref_name || github.sha }}
+          gpg-key: ${{ secrets.CI_GPG_SIGNING_KEY }}
+          gpg-key-passphrase: ${{ secrets.CI_GPG_SIGNING_PASSPHRASE }}
 
-  #     - name: Check out code
-  #       uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-  #         # Check https://github.com/livepeer/go-livepeer/pull/1891
-  #         # for ref value discussion
-  #         ref: ${{ github.event.pull_request.head.sha }}
+      - name: Generate branch manifest
+        id: branch-manifest
+        uses: livepeer/branch-manifest-action@latest
+        with:
+          project-name: analyzer
+          bucket-key: ${{ github.event.repository.name }}
 
-  #     - name: Restore cache
-  #       uses: actions/cache@v3
-  #       with:
-  #         path: |
-  #           ~/.cache/go-build
-  #           ~/go/pkg/mod
-  #         key: ${{ runner.os }}-${{ matrix.arch }}-go-${{ hashFiles('**/go.sum') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-${{ matrix.arch }}-go-
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v0
+        with:
+          workload_identity_provider: ${{ secrets.CI_GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.CI_GOOGLE_SERVICE_ACCOUNT }}
 
-  #     - name: Download dependencies
-  #       run: go mod download
+      - name: Upload release archives to Google Cloud
+        id: upload-archives
+        uses: google-github-actions/upload-cloud-storage@v0
+        with:
+          path: "releases"
+          destination: "build.livepeer.live/${{ github.event.repository.name }}/${{ (github.ref_type == 'tag' && github.ref_name) || github.sha }}"
+          parent: false
 
-  #     - name: Build
-  #       run: |
-  #         mkdir -p "build/" "releases/"
-  #         GOARCH="${{ matrix.arch }}" make
-  #         cd build/
-  #         mv analyzer.exe livepeer-analyzer.exe
-  #         zip -9q "../releases/livepeer-analyzer-windows-${{ matrix.arch }}.zip" "livepeer-analyzer.exe"
-
-  #     - name: Upload artifacts for cutting release
-  #       uses: actions/upload-artifact@master
-  #       with:
-  #         name: release-artifacts
-  #         path: releases/
+      - name: Upload branch manifest file
+        id: upload-manifest
+        uses: google-github-actions/upload-cloud-storage@v0
+        with:
+          path: ${{ steps.branch-manifest.outputs.manifest-file }}
+          destination: "build.livepeer.live/${{ github.event.repository.name }}/"
+          parent: false

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Export OS and platform env
         run: |
-          echo "GOOS=${{ matrix.platform }}" >> $GITHUB_ENV
+          echo "GOOS=${{ matrix.platform.name }}" >> $GITHUB_ENV
           echo "GOARCH=${{ matrix.arch }}" >> $GITHUB_ENV
 
       - name: Download dependencies
@@ -75,14 +75,14 @@ jobs:
           app-bundle-id: "org.livepeer.analyzer"
 
       - name: Archive binaries for windows
-        if: matrix.platform == 'windows'
+        if: matrix.platform.name == 'windows'
         run: |
           cd build/
           mv analyzer.exe livepeer-analyzer.exe
           zip -9q "../releases/livepeer-analyzer-${GOOS}-${GOARCH}.zip" livepeer-analyzer.exe
 
       - name: Archive binaries for not windows
-        if: matrix.platform != 'windows'
+        if: matrix.platform.name != 'windows'
         run: |
           cd build/
           mv analyzer livepeer-analyzer

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/livepeer/livepeer-data
 
-go 1.16
+go 1.17
 
 require (
 	github.com/golang/glog v1.0.0
@@ -13,4 +13,23 @@ require (
 	github.com/rabbitmq/amqp091-go v1.1.0
 	github.com/rabbitmq/rabbitmq-stream-go-client v1.0.0-rc12
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+)
+
+require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/snappy v0.0.4 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/klauspost/compress v1.15.0 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 // indirect
+	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
 )


### PR DESCRIPTION
Built binaries, are uploaded to gcp bucket for each commit. Additionally, merge multiple build jobs into a single one.

Part of work wrt: https://github.com/livepeer/livepeer-infra/issues/917

---

example manifest data:
```json
{
    "branch": "hjp/gcp-upload",
    "builds": {
        "darwin-amd64": "https://build.livepeer.live/livepeer-data/6e2cc7ab1cb332accdd7ee4088251f90a5e0db7e/livepeer-analyzer-darwin-amd64.tar.gz",
        "darwin-arm64": "https://build.livepeer.live/livepeer-data/6e2cc7ab1cb332accdd7ee4088251f90a5e0db7e/livepeer-analyzer-darwin-arm64.tar.gz",
        "linux-amd64": "https://build.livepeer.live/livepeer-data/6e2cc7ab1cb332accdd7ee4088251f90a5e0db7e/livepeer-analyzer-linux-amd64.tar.gz",
        "linux-arm64": "https://build.livepeer.live/livepeer-data/6e2cc7ab1cb332accdd7ee4088251f90a5e0db7e/livepeer-analyzer-linux-arm64.tar.gz",
        "windows-amd64": "https://build.livepeer.live/livepeer-data/6e2cc7ab1cb332accdd7ee4088251f90a5e0db7e/livepeer-analyzer-windows-amd64.zip",
        "windows-arm64": "https://build.livepeer.live/livepeer-data/6e2cc7ab1cb332accdd7ee4088251f90a5e0db7e/livepeer-analyzer-windows-arm64.zip"
    },
    "commit": "6e2cc7ab1cb332accdd7ee4088251f90a5e0db7e",
    "ref": "refs/pull/61/merge",
    "srcFilenames": {
        "darwin-amd64": "livepeer-analyzer-darwin-amd64.tar.gz",
        "darwin-arm64": "livepeer-analyzer-darwin-arm64.tar.gz",
        "linux-amd64": "livepeer-analyzer-linux-amd64.tar.gz",
        "linux-arm64": "livepeer-analyzer-linux-arm64.tar.gz",
        "windows-amd64": "livepeer-analyzer-windows-amd64.zip",
        "windows-arm64": "livepeer-analyzer-windows-arm64.zip"
    }
}
```