### PR TITLE
pkg/event: Improve reliability of AMQP consumer

### DIFF
--- a/pkg/event/amqp_consumer.go
+++ b/pkg/event/amqp_consumer.go
@@ -22,7 +22,7 @@ type unprocessableMessageErr struct{ error }
 
 // If error is not nil, wraps it in an unprocessable message error so the
 // consumer does not requeue the message.
-func UnprocessableIfErr(err error) error {
+func UnprocessableError(err error) error {
 	if err == nil {
 		return nil
 	}
@@ -218,7 +218,7 @@ func runHandlerRecovered(sub *subscription, msg amqp.Delivery) (err error) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			glog.Errorf("Panic in AMQP handler: value=%q stack:\n%s", rec, string(debug.Stack()))
-			err = UnprocessableIfErr(fmt.Errorf("panic: %v", rec))
+			err = UnprocessableError(fmt.Errorf("panic: %v", rec))
 		}
 	}()
 

--- a/pkg/event/amqp_consumer.go
+++ b/pkg/event/amqp_consumer.go
@@ -178,11 +178,11 @@ func doConsume(ctx context.Context, wg *sync.WaitGroup, amqpch AMQPChanOps, sub 
 						}
 						// the error likely means the msg was already requeued (e.g. conn
 						// reset), but let it fallthrough below and try a nack just in case.
-						err = fmt.Errorf("error ack-ing message: %w", err)
+						err = fmt.Errorf("error acking message: %w", err)
 					}
-					glog.Errorf("Nacking message due to error exchange=%q routingKey=%q err=%q", msg.Exchange, msg.RoutingKey, err)
+					glog.Errorf("Nacking message due to error exchange=%q queue=%q routingKey=%q err=%q", msg.Exchange, sub.queue, msg.RoutingKey, err)
 					if err := msg.Nack(false, true); err != nil {
-						glog.Errorf("Error nack-ing message exchange=%q routingKey=%q err=%q", msg.Exchange, msg.RoutingKey, err)
+						glog.Errorf("Error nacking message exchange=%q queue=%q routingKey=%q err=%q", msg.Exchange, sub.queue, msg.RoutingKey, err)
 					}
 				case <-ctx.Done():
 					return

--- a/pkg/event/amqp_consumer.go
+++ b/pkg/event/amqp_consumer.go
@@ -164,7 +164,10 @@ func doConsume(ctx context.Context, wg *sync.WaitGroup, amqpch AMQPChanOps, sub 
 			}()
 			for {
 				select {
-				case msg := <-subs:
+				case msg, ok := <-subs:
+					if !ok {
+						return
+					}
 					acker := msg.Acknowledger
 					msg.Acknowledger = nil // prevent handler from manually acking/nacking
 					err := sub.handler(msg)

--- a/pkg/event/amqp_consumer.go
+++ b/pkg/event/amqp_consumer.go
@@ -162,6 +162,8 @@ func doConsume(ctx context.Context, wg *sync.WaitGroup, amqpch AMQPChanOps, sub 
 					glog.Errorf("Panic in background AMQP consumer: value=%q stack:\n%s", rec, string(debug.Stack()))
 				}
 			}()
+			defer drain(subs)
+
 			for {
 				select {
 				case msg, ok := <-subs:
@@ -192,4 +194,10 @@ func doConsume(ctx context.Context, wg *sync.WaitGroup, amqpch AMQPChanOps, sub 
 		}()
 	}
 	return nil
+}
+
+func drain(ch <-chan amqp.Delivery) {
+	for msg := range ch {
+		msg.Nack(false, true)
+	}
 }


### PR DESCRIPTION
This is to improve reliability of the AMQP consumer after a few limitations noticed 
on the latest incident we had with `task-runner` panics.

Main changes:
 - Main fix: Recover from handler panics separately from panics in the consumer itself, and nack them [1]. A panic in the handler should not close the whole consumer.
 - Check when the subscription channel is closed and don't send an empty event to handlers
 - Try nacking the message when the ack fails (just to be extra safe. but the nack will likely also fail)
 - Make sure to drain the subscription channel on exit to avoid blocking the AMQP connection (as stated in the docs)
 - Created a special error type to be returned by consumer to indicate that the message should not be requeued
 - Made sure not to requeue panicked messages either

LFG

[1] Note: I realized that the cause of the incident wasn't actually that the failed events were clogging the front of the queue. Nacks sends the event back to the front of the queue, but we never really nacked the messages either. The real problem was that the panics just closed the consumer completely and so the instances eventually stopped reading any events.