### PR TITLE
api/handler: Move authorization before streamStatus

### DIFF
--- a/api/handler.go
+++ b/api/handler.go
@@ -92,12 +92,12 @@ func (h *apiHandler) streamHealthHandler() chi.Router {
 	healthcore, opts := h.core, h.opts
 
 	router := chi.NewRouter()
-	router.Use(
-		streamStatus(healthcore),
-		regionProxy(opts.RegionalHostFormat, opts.OwnRegion))
 	if opts.AuthURL != "" {
 		router.Use(authorization(opts.AuthURL))
 	}
+	router.Use(
+		streamStatus(healthcore),
+		regionProxy(opts.RegionalHostFormat, opts.OwnRegion))
 
 	h.withMetrics(router, "get_stream_health").
 		MethodFunc("GET", "/health", h.getStreamHealth)


### PR DESCRIPTION
After #129 I fixed the general OPTIONS handling, but there was 1 corner case
that I missed: we have a `streamStatus` middleware that tries to fetch the stream
healthy before we do any authorization. This meant that OPTIONS requests for
inexistent streams were getting a 404 error, even though it should be a 204 and
the 404 only come to the actual GET request.

This is a less critical issue, but still a confusing experince. So I moved the authorization
middleware to be the first one so it handles OPTIONS before anyone. I've also verified
that there were no dependencies between it and the region proxy / stream status middlewares,
I think it was only left to the end before to avoid authorizing twice in the case of cross-region
proxy. This is not a big issue though, so deal with the double auth.