### PR TITLE
views: Fix the query string breakdown casing

### DIFF
--- a/views/bigquery.go
+++ b/views/bigquery.go
@@ -45,17 +45,17 @@ func (s QuerySpec) GetSummaryQueryArgs() (playbackID string, ok bool) {
 }
 
 var viewershipBreakdownFields = map[string]string{
-	"device_type":    "device_type",
-	"device":         "device",
-	"cpu":            "cpu",
-	"os":             "os",
-	"browser":        "browser",
-	"browser_engine": "browser_engine",
-	"continent":      "playback_continent_name",
-	"country":        "playback_country_name",
-	"subdivision":    "playback_subdivisions_name",
-	"timezone":       "playback_timezone",
-	"viewer_id":      "viewer_id",
+	"deviceType":    "device_type",
+	"device":        "device",
+	"cpu":           "cpu",
+	"os":            "os",
+	"browser":       "browser",
+	"browserEngine": "browser_engine",
+	"continent":     "playback_continent_name",
+	"country":       "playback_country_name",
+	"subdivision":   "playback_subdivisions_name",
+	"timezone":      "playback_timezone",
+	"viewerId":      "viewer_id",
 }
 
 var allowedTimeSteps = map[string]bool{


### PR DESCRIPTION
They better be compatible to the fields
that we return on the response objects.
Those should be camelCase as its the pattern
in the current API, so made the breakdownBy
fields camelCase as well.

I was really confused with the API myself when writing
a code to breakdown by device_type then gets a deviceType
in the response 0o