### PR TITLE
api/views: Better separate summary from events queries

### DIFF
--- a/views/bigquery.go
+++ b/views/bigquery.go
@@ -27,23 +27,6 @@ type QuerySpec struct {
 	Detailed    bool
 }
 
-// GetSummaryQueryArgs returns the args to be used for a views summary query if
-// the provided query can be replaced by a summary query.
-// i.e. it is querying for the aggregate metrics of a single playback ID.
-func (s QuerySpec) GetSummaryQueryArgs() (playbackID string, ok bool) {
-	playbackID = s.Filter.PlaybackID
-	pidFilter := QueryFilter{PlaybackID: playbackID, UserID: s.Filter.UserID}
-
-	ok = playbackID != "" && !s.Detailed && s.Filter == pidFilter &&
-		s.From == nil && s.To == nil && s.TimeStep == "" &&
-		len(s.BreakdownBy) == 0
-
-	if !ok {
-		playbackID = ""
-	}
-	return
-}
-
 var viewershipBreakdownFields = map[string]string{
 	"deviceType":    "device_type",
 	"device":        "device",

--- a/views/bigquery.go
+++ b/views/bigquery.go
@@ -100,8 +100,9 @@ type ViewSummaryRow struct {
 	PlaybackID  string `bigquery:"playback_id"`
 	DStorageURL string `bigquery:"d_storage_url"`
 
-	ViewCount    int64   `bigquery:"view_count"`
-	PlaytimeMins float64 `bigquery:"playtime_mins"`
+	ViewCount       int64   `bigquery:"view_count"`
+	LegacyViewCount int64   `bigquery:"legacy_view_count"`
+	PlaytimeMins    float64 `bigquery:"playtime_mins"`
 }
 
 type BigQuery interface {
@@ -239,6 +240,7 @@ func buildViewsSummaryQuery(table string, playbackID string) (string, []interfac
 
 	query := squirrel.Select(
 		"cast(sum(view_count) as INT64) as view_count",
+		"cast(sum(old_view_count) as INT64) as legacy_view_count",
 		"coalesce(cast(sum(playtime_hrs) as FLOAT64), 0) * 60.0 as playtime_mins").
 		From(table).
 		Limit(2)

--- a/views/client.go
+++ b/views/client.go
@@ -40,6 +40,10 @@ type Metric struct {
 	RebufferRatio     *float64 `json:"rebufferRatio,omitempty"`
 	ErrorRate         *float64 `json:"errorRate,omitempty"`
 	ExistsBeforeStart *float64 `json:"existsBeforeStart,omitempty"`
+	// Present only on the summary queries. These were imported from the
+	// prometheus data we had on the first version of this API and are not
+	// shown in the detailed metrics queries (non-/total).
+	LegacyViewCount int64 `json:"legacyViewCount,omitempty"`
 }
 
 type ClientOptions struct {
@@ -191,9 +195,10 @@ func viewershipSummaryToMetric(filter QueryFilter, summary *ViewSummaryRow) []Me
 	}
 
 	return []Metric{{
-		PlaybackID:   summary.PlaybackID,
-		DStorageURL:  summary.DStorageURL,
-		ViewCount:    summary.ViewCount,
-		PlaytimeMins: summary.PlaytimeMins,
+		PlaybackID:      summary.PlaybackID,
+		DStorageURL:     summary.DStorageURL,
+		ViewCount:       summary.ViewCount,
+		LegacyViewCount: summary.LegacyViewCount,
+		PlaytimeMins:    summary.PlaytimeMins,
 	}}
 }


### PR DESCRIPTION
I found out after the initial version that the viewership summary and viewership
events tables don't actually have the same data: the summary one has the 
prometheus data backward compatibility while the events one does not.

To make that distinction clearer to the end-user, added a new metric on the
summary query responses called `legacyViewCount`, which contains the
number of views that have been migrated from the prometheus data and 
thus will not show up in the detailed query endpoints.

Also removed a refactor that did a cheaper summary query when the 
events query was made with just a playback ID. This is not possible anymore,
since the tables contain different data, so we cannot replace one query with 
the other. 

The coded ended up a little simpler tho, without magic attempt to detect what
kind of query it is, which could also lead to unexpected bugs like something
changing and we stopping the use of the summary table altogether.