### PR TITLE
Introduce new event type for source playback

### DIFF
--- a/pkg/data/parse.go
+++ b/pkg/data/parse.go
@@ -47,6 +47,12 @@ func ParseEvent(data []byte) (Event, error) {
 			return nil, fmt.Errorf("error unmarshalling task result event: %w", err)
 		}
 		return trev, nil
+	case EventTypeTaskResultPartial:
+		var event *TaskResultPartialEvent
+		if err := json.Unmarshal(data, &event); err != nil {
+			return nil, fmt.Errorf("error unmarshalling task partial result event: %w", err)
+		}
+		return event, nil
 	default:
 		return nil, fmt.Errorf("unknown event type=%q, streamId=%q, ts=%v", base.Type(), base.StreamID_, base.Timestamp_)
 	}

--- a/pkg/data/task_partial_result.go
+++ b/pkg/data/task_partial_result.go
@@ -2,13 +2,20 @@ package data
 
 const EventTypeTaskResultPartial EventType = "task_result_partial"
 
-func NewTaskResultPartialEvent(info TaskInfo, err *ErrorInfo, output *TaskOutput) *TaskResultPartialEvent {
+func NewTaskResultPartialEvent(info TaskInfo, output *TaskPartialOutput) *TaskResultPartialEvent {
 	return &TaskResultPartialEvent{
 		Base:   newEventBase(EventTypeTaskResultPartial, ""),
 		Task:   info,
-		Error:  err,
 		Output: output,
 	}
 }
 
-type TaskResultPartialEvent TaskResultEvent
+type TaskResultPartialEvent struct {
+	Base
+	Task   TaskInfo           `json:"task"`
+	Output *TaskPartialOutput `json:"output,omitempty"`
+}
+
+type TaskPartialOutput struct {
+	Upload *UploadTaskOutput `json:"upload,omitempty"`
+}

--- a/pkg/data/task_partial_result.go
+++ b/pkg/data/task_partial_result.go
@@ -1,0 +1,14 @@
+package data
+
+const EventTypeTaskResultPartial EventType = "task_result_partial"
+
+func NewTaskResultPartialEvent(info TaskInfo, err *ErrorInfo, output *TaskOutput) *TaskResultPartialEvent {
+	return &TaskResultPartialEvent{
+		Base:   newEventBase(EventTypeTaskResultPartial, ""),
+		Task:   info,
+		Error:  err,
+		Output: output,
+	}
+}
+
+type TaskResultPartialEvent TaskResultEvent


### PR DESCRIPTION
We'll use this to notify from task-runner to studio about the availability of source playback