### PR TITLE
analyzer: Fixes for running analyzer in diverse local environments

### DIFF
--- a/api/streamStatus.go
+++ b/api/streamStatus.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	"github.com/livepeer/livepeer-data/health"
@@ -16,6 +17,11 @@ const (
 
 func streamStatus(healthcore *health.Core) middleware {
 	return inlineMiddleware(func(rw http.ResponseWriter, r *http.Request, next http.Handler) {
+		if healthcore == nil {
+			respondError(rw, http.StatusNotImplemented, errors.New("stream healthcore is unavailable"))
+			return
+		}
+
 		streamID := apiParam(r, streamIDParam)
 		if streamID == "" {
 			next.ServeHTTP(rw, r)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.2"
 services:
   rabbitmq:
-    image: rabbitmq:3.9-rc-management
+    image: rabbitmq:3-management
     container_name: rabbitmq
     ports:
       - 5552:5552


### PR DESCRIPTION
Some VPNs are messing up with the RabbitMQ connection so let's allow running without it.