### PR TITLE
reducers: Fix NRE in media server metrics

### DIFF
--- a/health/reducers/media_server_metrics.go
+++ b/health/reducers/media_server_metrics.go
@@ -38,7 +38,7 @@ func (t MediaServerMetrics) Reduce(current *data.HealthStatus, _ interface{}, ev
 
 	metrics := current.MetricsCopy()
 	ts, dims := evt.Timestamp(), map[string]string{"region": evt.Region, "nodeId": evt.NodeID}
-	if evt.Stats.MediaTimeMs != nil {
+	if evt.Stats != nil && evt.Stats.MediaTimeMs != nil {
 		metrics.Add(data.NewMetric(MetricMediaTimeMillis, dims, ts, float64(*evt.Stats.MediaTimeMs)))
 	}
 	for _, ms := range evt.Multistream {


### PR DESCRIPTION
Some events are coming without stats apparently. Don't really know why but the reducer should be resilient to that.