### PR TITLE
health: Fix yet another NRE and improve panic handling

### DIFF
--- a/health/reducers/media_server_metrics.go
+++ b/health/reducers/media_server_metrics.go
@@ -54,7 +54,7 @@ func (t MediaServerMetrics) Reduce(current *data.HealthStatus, _ interface{}, ev
 }
 
 func multistreamMetrics(current *data.HealthStatus, ts time.Time, nodeID, region string, ms *data.MultistreamTargetMetrics) []*data.Metric {
-	if ms.Metrics == nil {
+	if ms == nil || ms.Metrics == nil {
 		return nil
 	}
 	msDims := map[string]string{


### PR DESCRIPTION
This fixes another NRE found on the media server metrics code, which for some reason are getting some nil values sometimes.

Since we've been getting some of these frequently I also made some improvemenets to the panic handling code:
 - On the "rabbitmq stream consumer", include the message data in the panic log
 - On the "health core", recover from panics in reducers and skip the event instead of restarting the app