### PR TITLE
usage: query usage for recently active users

### DIFF
--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -95,6 +95,7 @@ func parseFlags(version string) cliFlags {
 	fs.StringVar(&cli.viewsOpts.ViewershipSummaryTable, "viewership-summary-table", "livepeer-analytics.viewership.staging_viewership_summary_by_video", "BigQuery table to read viewership summarized metrics from")
 	fs.StringVar(&cli.usageOpts.HourlyUsageTable, "hourly-usage-table", "livepeer-analytics.staging.hourly_billing_usage", "BigQuery table to read hourly usage metrics from")
 	fs.StringVar(&cli.usageOpts.DailyUsageTable, "daily-data-table", "livepeer-analytics.staging.explorer_day_data", "BigQuery table to read total usage metrics from")
+	fs.StringVar(&cli.usageOpts.UsersTable, "users-table", "livepeer-analytics.staging.studio_users", "BigQuery table to read studio users from")
 	fs.Int64Var(&cli.viewsOpts.MaxBytesBilledPerBigQuery, "max-bytes-billed-per-big-query", 100*1024*1024 /* 100 MB */, "Max bytes billed configuration to use for the queries to BigQuery")
 
 	flag.Set("logtostderr", "true")

--- a/usage/client.go
+++ b/usage/client.go
@@ -56,3 +56,12 @@ func (c *Client) QueryTotalSummary(ctx context.Context, spec FromToQuerySpec) (*
 
 	return summary, nil
 }
+
+func (c *Client) QueryActiveUsageSummary(ctx context.Context, spec FromToQuerySpec) (*[]ActiveUsersSummaryRow, error) {
+	summary, err := c.bigquery.QueryActiveUsersUsageSummary(ctx, spec)
+	if err != nil {
+		return nil, err
+	}
+
+	return summary, nil
+}

--- a/usage/client.go
+++ b/usage/client.go
@@ -65,3 +65,12 @@ func (c *Client) QueryActiveUsageSummary(ctx context.Context, spec FromToQuerySp
 
 	return summary, nil
 }
+
+func (c *Client) QueryGroupedUsageSummary(ctx context.Context, spec GroupedQuerySpec) (*[]ActiveUsersSummaryRow, error) {
+	summary, err := c.bigquery.QueryGroupedUsageSummary(ctx, spec)
+	if err != nil {
+		return nil, err
+	}
+
+	return summary, nil
+}

--- a/usage/client.go
+++ b/usage/client.go
@@ -65,12 +65,3 @@ func (c *Client) QueryActiveUsageSummary(ctx context.Context, spec FromToQuerySp
 
 	return summary, nil
 }
-
-func (c *Client) QueryGroupedUsageSummary(ctx context.Context, spec GroupedQuerySpec) (*[]GroupedUsageRow, error) {
-	summary, err := c.bigquery.QueryGroupedUsageSummary(ctx, spec)
-	if err != nil {
-		return nil, err
-	}
-
-	return summary, nil
-}

--- a/usage/client.go
+++ b/usage/client.go
@@ -66,7 +66,7 @@ func (c *Client) QueryActiveUsageSummary(ctx context.Context, spec FromToQuerySp
 	return summary, nil
 }
 
-func (c *Client) QueryGroupedUsageSummary(ctx context.Context, spec GroupedQuerySpec) (*[]ActiveUsersSummaryRow, error) {
+func (c *Client) QueryGroupedUsageSummary(ctx context.Context, spec GroupedQuerySpec) (*[]GroupedUsageRow, error) {
 	summary, err := c.bigquery.QueryGroupedUsageSummary(ctx, spec)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This removes any need to fetch users by activity on studio and doing multiple api calls to data to retrieve usage for these users. In a single api, you can fetch usage for active users in a requested timeframe

Also, this creates a new endpoint `grouped` where you can pass a list of userIds with their billing cycle and retrieve their usage in a single query