### PR TITLE
Fix returning nulls from /data/views/query if no data in BigQuery

### DIFF
--- a/views/bigquery.go
+++ b/views/bigquery.go
@@ -80,8 +80,8 @@ type ViewershipEventRow struct {
 
 	// metric data
 
-	ViewCount        int64                `bigquery:"view_count"`
-	PlaytimeMins     float64              `bigquery:"playtime_mins"`
+	ViewCount        bigquery.NullInt64   `bigquery:"view_count"`
+	PlaytimeMins     bigquery.NullFloat64 `bigquery:"playtime_mins"`
 	TtffMs           bigquery.NullFloat64 `bigquery:"ttff_ms"`
 	RebufferRatio    bigquery.NullFloat64 `bigquery:"rebuffer_ratio"`
 	ErrorRate        bigquery.NullFloat64 `bigquery:"error_rate"`
@@ -92,9 +92,9 @@ type ViewSummaryRow struct {
 	PlaybackID  bigquery.NullString `bigquery:"playback_id"`
 	DStorageURL bigquery.NullString `bigquery:"d_storage_url"`
 
-	ViewCount       int64              `bigquery:"view_count"`
-	LegacyViewCount bigquery.NullInt64 `bigquery:"legacy_view_count"`
-	PlaytimeMins    float64            `bigquery:"playtime_mins"`
+	ViewCount       bigquery.NullInt64   `bigquery:"view_count"`
+	LegacyViewCount bigquery.NullInt64   `bigquery:"legacy_view_count"`
+	PlaytimeMins    bigquery.NullFloat64 `bigquery:"playtime_mins"`
 }
 
 type BigQuery interface {

--- a/views/prometheus.go
+++ b/views/prometheus.go
@@ -7,14 +7,15 @@ import (
 
 	"github.com/golang/glog"
 	livepeer "github.com/livepeer/go-api-client"
+	"github.com/livepeer/livepeer-data/pkg/data"
 	promClient "github.com/prometheus/client_golang/api"
 	prometheus "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 )
 
 type TotalViews struct {
-	ID         string `json:"id"`
-	StartViews int64  `json:"startViews"`
+	ID         string               `json:"id"`
+	StartViews data.Nullable[int64] `json:"startViews"`
 }
 
 type Prometheus struct {


### PR DESCRIPTION
Before this PR, if BigQuery returns null in some of the columns, then a call to `/data/views/query` returns an error:
```
"bigquery error: error reading query result: bigquery: NULL cannot be assigned to field `PlaytimeMins` of type float64"
```

After this change, it will return the following:
```
[
    {
        "viewCount": 0,
        "playtimeMins": null,
        "ttffMs": null,
        "rebufferRatio": null,
        "errorRate": null,
        "exitsBeforeStart": null
    }
]
```

Related to https://linear.app/livepeer/issue/PS-191/grafana-engagement-data-issues, though it does no solve the root cause of that issue.