### PR TITLE
Fix BigQuery select with null values

### DIFF
--- a/views/bigquery.go
+++ b/views/bigquery.go
@@ -163,10 +163,10 @@ func buildViewsEventsQuery(table string, spec QuerySpec) (string, []interface{},
 
 	if spec.Detailed {
 		query = query.Columns(
-			"ifnull(avg(ttff_ms), 0) as ttff_ms",
-			"ifnull(avg(rebuffer_ratio), 0) as rebuffer_ratio",
-			"ifnull(avg(if(error_count > 0, 1, 0)), 0) as error_rate",
-			"ifnull(sum(if(exit_before_start, 1.0, 0.0)), 0) as exits_before_start")
+			"avg(ttff_ms) as ttff_ms",
+			"avg(rebuffer_ratio) as rebuffer_ratio",
+			"avg(if(error_count > 0, 1, 0)) as error_rate",
+			"sum(if(exit_before_start, 1.0, 0.0)) as exits_before_start")
 	}
 
 	if creatorId := spec.Filter.CreatorID; creatorId != "" {

--- a/views/bigquery.go
+++ b/views/bigquery.go
@@ -155,7 +155,7 @@ func (bq *bigqueryHandler) QueryViewsEvents(ctx context.Context, spec QuerySpec)
 func buildViewsEventsQuery(table string, spec QuerySpec) (string, []interface{}, error) {
 	query := squirrel.Select(
 		"countif(play_intent) as view_count",
-		"sum(playtime_ms) / 60000.0 as playtime_mins").
+		"ifnull(sum(playtime_ms), 0) / 60000.0 as playtime_mins").
 		From(table).
 		Where("account_id = ?", spec.Filter.UserID).
 		Limit(maxBigQueryResultRows + 1)
@@ -163,10 +163,10 @@ func buildViewsEventsQuery(table string, spec QuerySpec) (string, []interface{},
 
 	if spec.Detailed {
 		query = query.Columns(
-			"avg(ttff_ms) as ttff_ms",
-			"avg(rebuffer_ratio) as rebuffer_ratio",
-			"avg(if(error_count > 0, 1, 0)) as error_rate",
-			"sum(if(exit_before_start, 1.0, 0.0)) as exits_before_start")
+			"ifnull(avg(ttff_ms), 0) as ttff_ms",
+			"ifnull(avg(rebuffer_ratio), 0) as rebuffer_ratio",
+			"ifnull(avg(if(error_count > 0, 1, 0)), 0) as error_rate",
+			"ifnull(sum(if(exit_before_start, 1.0, 0.0)), 0) as exits_before_start")
 	}
 
 	if creatorId := spec.Filter.CreatorID; creatorId != "" {

--- a/views/bigquery_test.go
+++ b/views/bigquery_test.go
@@ -23,7 +23,7 @@ func TestCallsBigQueryClient(t *testing.T) {
 	_, err := bq.QueryViewsEvents(context.Background(), QuerySpec{})
 	require.ErrorContains(err, "dry-run")
 
-	require.Equal("SELECT countif(play_intent) as view_count, sum(playtime_ms) / 60000.0 as playtime_mins "+
+	require.Equal("SELECT countif(play_intent) as view_count, ifnull(sum(playtime_ms), 0) / 60000.0 as playtime_mins "+
 		"FROM bq_events WHERE account_id = ? LIMIT 10001", receivedQuery)
 }
 


### PR DESCRIPTION
Before this PR, if BigQuery returns null in some of the columns, then a call to /data/views/query returns an error:

"bigquery error: error reading query result: bigquery: NULL cannot be assigned to field `PlaytimeMins` of type float64"
After this change, it will return the following:

```
[
    {
        "viewCount": 0,
        "playtimeMins": 0,
        "ttffMs": 0,
        "rebufferRatio": 0,
        "errorRate": 0,
        "exitsBeforeStart": 0
    }
]
```

Related to https://linear.app/livepeer/issue/PS-191/grafana-engagement-data-issues, though it does no solve the root cause of that issue.