### PR TITLE
Usage API: breakdownBy=creatorId

### DIFF
--- a/api/authorization.go
+++ b/api/authorization.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/golang/glog"
@@ -93,7 +94,7 @@ func authorization(authUrl string) middleware {
 			r = r.WithContext(ctx)
 		}
 
-		if isCallerAdmin := authRes.Header.Get("X-Livepeer-Is-Caller-Admin"); isCallerAdmin != "" {
+		if isCallerAdmin, err := strconv.ParseBool(r.Header.Get("X-Livepeer-Is-Caller-Admin")); err == nil {
 			ctx := context.WithValue(r.Context(), isCallerAdminContextKey, isCallerAdmin)
 			r = r.WithContext(ctx)
 		}
@@ -129,4 +130,18 @@ func copyHeaders(headers []string, src, dest http.Header) {
 			dest[header] = vals
 		}
 	}
+}
+
+func callerUserId(r *http.Request) string {
+	if val, ok := r.Context().Value(userIdContextKey).(string); ok {
+		return val
+	}
+	return ""
+}
+
+func isCallerAdmin(r *http.Request) bool {
+	if val, ok := r.Context().Value(isCallerAdminContextKey).(bool); ok {
+		return val
+	}
+	return false
 }

--- a/api/authorization.go
+++ b/api/authorization.go
@@ -94,7 +94,7 @@ func authorization(authUrl string) middleware {
 			r = r.WithContext(ctx)
 		}
 
-		if isCallerAdmin, err := strconv.ParseBool(r.Header.Get("X-Livepeer-Is-Caller-Admin")); err == nil {
+		if isCallerAdmin, err := strconv.ParseBool(authRes.Header.Get("X-Livepeer-Is-Caller-Admin")); err == nil {
 			ctx := context.WithValue(r.Context(), isCallerAdminContextKey, isCallerAdmin)
 			r = r.WithContext(ctx)
 		}

--- a/api/handler.go
+++ b/api/handler.go
@@ -281,8 +281,8 @@ func (h *apiHandler) queryViewership(detailed bool) http.HandlerFunc {
 			return
 		}
 
-		userId, ok := r.Context().Value(userIdContextKey).(string)
-		if !ok {
+		userId := callerUserId(r)
+		if userId == "" {
 			respondError(rw, http.StatusInternalServerError, errors.New("request not authenticated"))
 			return
 		}
@@ -322,20 +322,14 @@ func (h *apiHandler) queryUsage() http.HandlerFunc {
 			return
 		}
 
-		userId, ok := r.Context().Value(userIdContextKey).(string)
-		if !ok {
+		userId := callerUserId(r)
+		if userId == "" {
 			respondError(rw, http.StatusInternalServerError, errors.New("request not authenticated"))
 			return
 		}
 
-		isCallerAdmin, ok := r.Context().Value(isCallerAdminContextKey).(string)
-
 		if qs := r.URL.Query(); qs.Has("userId") {
-			if !ok {
-				respondError(rw, http.StatusInternalServerError, errors.New("request not authenticated - cannot retrieve usage for other users"))
-				return
-			}
-			if isCallerAdmin != "true" {
+			if !isCallerAdmin(r) {
 				respondError(rw, http.StatusForbidden, errors.New("only admins can query usage for other users"))
 				return
 			}
@@ -387,20 +381,12 @@ func (h *apiHandler) queryTotalUsage() http.HandlerFunc {
 			return
 		}
 
-		_, ok := r.Context().Value(userIdContextKey).(string)
-		if !ok {
+		if userId := callerUserId(r); userId == "" {
 			respondError(rw, http.StatusInternalServerError, errors.New("request not authenticated"))
 			return
 		}
 
-		isCallerAdmin, ok := r.Context().Value(isCallerAdminContextKey).(string)
-
-		if !ok {
-			respondError(rw, http.StatusInternalServerError, errors.New("request not authenticated - unable to determine if caller is admin"))
-			return
-		}
-
-		if isCallerAdmin != "true" {
+		if !isCallerAdmin(r) {
 			respondError(rw, http.StatusForbidden, errors.New("only admins can query total usage"))
 			return
 		}
@@ -433,20 +419,12 @@ func (h *apiHandler) queryActiveUsersUsage() http.HandlerFunc {
 			return
 		}
 
-		_, ok := r.Context().Value(userIdContextKey).(string)
-		if !ok {
+		if userId := callerUserId(r); userId == "" {
 			respondError(rw, http.StatusInternalServerError, errors.New("request not authenticated"))
 			return
 		}
 
-		isCallerAdmin, ok := r.Context().Value(isCallerAdminContextKey).(string)
-
-		if !ok {
-			respondError(rw, http.StatusInternalServerError, errors.New("request not authenticated - unable to determine if caller is admin"))
-			return
-		}
-
-		if isCallerAdmin != "true" {
+		if !isCallerAdmin(r) {
 			respondError(rw, http.StatusForbidden, errors.New("only admins can query active users"))
 			return
 		}
@@ -494,7 +472,7 @@ func (h *apiHandler) getTotalViews(rw http.ResponseWriter, r *http.Request) {
 		}}
 	}
 
-	userId := r.Context().Value(userIdContextKey)
+	userId := callerUserId(r)
 	glog.Infof("Used deprecated get total views endpoint userId=%v assetId=%v playbackId=%v oldStartViews=%v newViewCount=%v",
 		userId, assetID, totalViews[0].ID, oldStartViews, totalViews[0].StartViews)
 

--- a/api/handler.go
+++ b/api/handler.go
@@ -343,7 +343,6 @@ func (h *apiHandler) queryUsage() http.HandlerFunc {
 		}
 
 		qs := r.URL.Query()
-		creatorId := qs.Get("creatorId")
 
 		query := usage.QuerySpec{
 			From:     from,
@@ -353,10 +352,11 @@ func (h *apiHandler) queryUsage() http.HandlerFunc {
 				UserID:    userId,
 				CreatorID: qs.Get("creatorId"),
 			},
+			BreakdownBy: qs["breakdownBy[]"],
 		}
 
 		if qs.Get("timeStep") == "" {
-			usage, err := h.usage.QuerySummary(r.Context(), userId, creatorId, query)
+			usage, err := h.usage.QuerySummary(r.Context(), userId, query)
 			if err != nil {
 				respondError(rw, http.StatusInternalServerError, err)
 				return
@@ -364,7 +364,7 @@ func (h *apiHandler) queryUsage() http.HandlerFunc {
 
 			respondJson(rw, http.StatusOK, usage)
 		} else {
-			usage, err := h.usage.QuerySummaryWithTimestep(r.Context(), userId, creatorId, query)
+			usage, err := h.usage.QuerySummaryWithTimestep(r.Context(), userId, query)
 			if err != nil {
 				respondError(rw, http.StatusInternalServerError, err)
 				return

--- a/api/handler.go
+++ b/api/handler.go
@@ -356,7 +356,7 @@ func (h *apiHandler) queryUsage() http.HandlerFunc {
 		}
 
 		if qs.Get("timeStep") == "" {
-			usage, err := h.usage.QuerySummary(r.Context(), userId, query)
+			usage, err := h.usage.QuerySummary(r.Context(), query)
 			if err != nil {
 				respondError(rw, http.StatusInternalServerError, err)
 				return
@@ -364,7 +364,7 @@ func (h *apiHandler) queryUsage() http.HandlerFunc {
 
 			respondJson(rw, http.StatusOK, usage)
 		} else {
-			usage, err := h.usage.QuerySummaryWithTimestep(r.Context(), userId, query)
+			usage, err := h.usage.QuerySummaryWithTimestep(r.Context(), query)
 			if err != nil {
 				respondError(rw, http.StatusInternalServerError, err)
 				return

--- a/api/handler.go
+++ b/api/handler.go
@@ -349,7 +349,7 @@ func (h *apiHandler) queryUsage() http.HandlerFunc {
 			BreakdownBy: qs["breakdownBy[]"],
 		}
 
-		if qs.Get("timeStep") == "" {
+		if !query.HasAnyBreakdown() {
 			usage, err := h.usage.QuerySummary(r.Context(), query)
 			if err != nil {
 				respondError(rw, http.StatusInternalServerError, err)
@@ -358,7 +358,7 @@ func (h *apiHandler) queryUsage() http.HandlerFunc {
 
 			respondJson(rw, http.StatusOK, usage)
 		} else {
-			usage, err := h.usage.QuerySummaryWithTimestep(r.Context(), query)
+			usage, err := h.usage.QuerySummaryWithBreakdown(r.Context(), query)
 			if err != nil {
 				respondError(rw, http.StatusInternalServerError, err)
 				return

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -96,7 +96,7 @@ func parseFlags(version string) cliFlags {
 	fs.StringVar(&cli.usageOpts.HourlyUsageTable, "hourly-usage-table", "livepeer-analytics.staging.hourly_billing_usage", "BigQuery table to read hourly usage metrics from")
 	fs.StringVar(&cli.usageOpts.DailyUsageTable, "daily-data-table", "livepeer-analytics.staging.explorer_day_data", "BigQuery table to read total usage metrics from")
 	fs.StringVar(&cli.usageOpts.UsersTable, "users-table", "livepeer-analytics.staging.studio_users", "BigQuery table to read studio users from")
-	fs.Int64Var(&cli.viewsOpts.MaxBytesBilledPerBigQuery, "max-bytes-billed-per-big-query", 1000*1024*1024 /* 100 MB */, "Max bytes billed configuration to use for the queries to BigQuery")
+	fs.Int64Var(&cli.viewsOpts.MaxBytesBilledPerBigQuery, "max-bytes-billed-per-big-query", 100*1024*1024 /* 100 MB */, "Max bytes billed configuration to use for the queries to BigQuery")
 
 	flag.Set("logtostderr", "true")
 	glogVFlag := flag.Lookup("v")

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -96,7 +96,7 @@ func parseFlags(version string) cliFlags {
 	fs.StringVar(&cli.usageOpts.HourlyUsageTable, "hourly-usage-table", "livepeer-analytics.staging.hourly_billing_usage", "BigQuery table to read hourly usage metrics from")
 	fs.StringVar(&cli.usageOpts.DailyUsageTable, "daily-data-table", "livepeer-analytics.staging.explorer_day_data", "BigQuery table to read total usage metrics from")
 	fs.StringVar(&cli.usageOpts.UsersTable, "users-table", "livepeer-analytics.staging.studio_users", "BigQuery table to read studio users from")
-	fs.Int64Var(&cli.viewsOpts.MaxBytesBilledPerBigQuery, "max-bytes-billed-per-big-query", 100*1024*1024 /* 100 MB */, "Max bytes billed configuration to use for the queries to BigQuery")
+	fs.Int64Var(&cli.viewsOpts.MaxBytesBilledPerBigQuery, "max-bytes-billed-per-big-query", 1000*1024*1024 /* 100 MB */, "Max bytes billed configuration to use for the queries to BigQuery")
 
 	flag.Set("logtostderr", "true")
 	glogVFlag := flag.Lookup("v")

--- a/usage/bigquery.go
+++ b/usage/bigquery.go
@@ -9,7 +9,6 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"github.com/Masterminds/squirrel"
-	"github.com/golang/glog"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
@@ -134,14 +133,11 @@ type bigqueryHandler struct {
 // usage summary query
 
 func (bq *bigqueryHandler) QueryUsageSummary(ctx context.Context, userID string, spec QuerySpec) ([]UsageSummaryRow, error) {
-	glog.V(10).Infof("QueryUsageSummary: userID=%s, creatorID=%s, spec=%+v", userID, spec)
 	sql, args, err := buildUsageSummaryQuery(bq.opts.HourlyUsageTable, userID, spec)
 	if err != nil {
 		return nil, fmt.Errorf("error building usage summary query: %w", err)
 	}
-	glog.V(10).Infof("QueryUsageSummary: sql=%s, args=%v", sql, args)
 	bqRows, err := doBigQuery[UsageSummaryRow](bq, ctx, sql, args)
-	// glog.V(10).Infof("QueryUsageSummary: bqRows=%s", bqRows)
 	if err != nil {
 		return nil, fmt.Errorf("bigquery error: %w", err)
 	} else if len(bqRows) > maxBigQueryResultRows {
@@ -156,13 +152,11 @@ func (bq *bigqueryHandler) QueryUsageSummary(ctx context.Context, userID string,
 }
 
 func (bq *bigqueryHandler) QueryUsageSummaryWithTimestep(ctx context.Context, userID string, spec QuerySpec) ([]UsageSummaryRow, error) {
-	glog.V(10).Infof("QueryUsageSummaryWithTimestep: userID=%s, spec=%+v", userID, spec)
 
 	sql, args, err := buildUsageSummaryQuery(bq.opts.HourlyUsageTable, userID, spec)
 	if err != nil {
 		return nil, fmt.Errorf("error building usage summary query: %w", err)
 	}
-	glog.V(10).Infof("QueryUsageSummaryWithTimestep: sql=%s, args=%v", sql, args)
 
 	bqRows, err := doBigQuery[UsageSummaryRow](bq, ctx, sql, args)
 	if err != nil {
@@ -369,7 +363,6 @@ func doBigQuery[RowT any](bq *bigqueryHandler, ctx context.Context, sql string, 
 	}
 
 	typed, err := toTypedValues[RowT](it)
-	// glog.V(10).Infof("typed: %s", typed)
 
 	return typed, err
 }
@@ -392,10 +385,8 @@ func toTypedValues[RowT any](it *bigquery.RowIterator) ([]RowT, error) {
 		} else if err != nil {
 			return nil, fmt.Errorf("error reading query result: %w", err)
 		}
-		glog.V(10).Infof("values: %s", row)
 
 		values = append(values, row)
 	}
-	glog.V(10).Infof("values: %s %d", values[0], len(values))
 	return values, nil
 }

--- a/usage/bigquery.go
+++ b/usage/bigquery.go
@@ -362,9 +362,7 @@ func doBigQuery[RowT any](bq *bigqueryHandler, ctx context.Context, sql string, 
 		return nil, fmt.Errorf("error running query: %w", err)
 	}
 
-	typed, err := toTypedValues[RowT](it)
-
-	return typed, err
+	return toTypedValues[RowT](it)
 }
 
 func toBigQueryParameters(args []interface{}) []bigquery.QueryParameter {

--- a/usage/bigquery.go
+++ b/usage/bigquery.go
@@ -13,31 +13,6 @@ import (
 	"google.golang.org/api/option"
 )
 
-type QueryFilter struct {
-	CreatorID string
-	UserID    string
-}
-
-type QuerySpec struct {
-	TimeStep    string
-	From, To    *time.Time
-	Filter      QueryFilter
-	BreakdownBy []string
-}
-
-var usageBreakdownFields = map[string]string{
-	"creatorId": "creator_id",
-}
-
-type FromToQuerySpec struct {
-	From, To *time.Time
-}
-
-var allowedTimeSteps = map[string]bool{
-	"hour": true,
-	"day":  true,
-}
-
 type UsageSummaryRow struct {
 	UserID       string              `bigquery:"user_id"`
 	CreatorID    bigquery.NullString `bigquery:"creator_id"`

--- a/usage/client.go
+++ b/usage/client.go
@@ -56,9 +56,10 @@ func (c *Client) QuerySummary(ctx context.Context, spec QuerySpec) (*Metric, err
 }
 
 func usageSummaryToMetric(row *UsageSummaryRow, spec QuerySpec) *Metric {
+	inclCreatorID := spec.Filter.CreatorID != "" || spec.hasBreakdownBy("creatorId")
 	m := &Metric{
 		UserID:            row.UserID,
-		CreatorID:         toStringPtr(row.CreatorID, spec.hasBreakdownBy("creatorId")),
+		CreatorID:         toStringPtr(row.CreatorID, inclCreatorID),
 		DeliveryUsageMins: toFloat64Ptr(row.DeliveryUsageMins, true),
 		TotalUsageMins:    toFloat64Ptr(row.TotalUsageMins, true),
 		StorageUsageMins:  toFloat64Ptr(row.StorageUsageMins, true),

--- a/usage/client.go
+++ b/usage/client.go
@@ -3,9 +3,25 @@ package usage
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"cloud.google.com/go/bigquery"
 	livepeer "github.com/livepeer/go-api-client"
+	"github.com/livepeer/livepeer-data/pkg/data"
 )
+
+type Metric struct {
+	TimeInterval *int64 `json:"TimeInterval,omitempty"`
+
+	// breakdown fields
+	UserID    string                `json:"UserID,omitempty"`
+	CreatorID data.Nullable[string] `json:"CreatorID,omitempty"`
+
+	// metric data
+	DeliveryUsageMins data.Nullable[float64] `json:"DeliveryUsageMins,omitempty"`
+	TotalUsageMins    data.Nullable[float64] `json:"TotalUsageMins,omitempty"`
+	StorageUsageMins  data.Nullable[float64] `json:"StorageUsageMins,omitempty"`
+}
 
 type Client struct {
 	opts     ClientOptions
@@ -30,8 +46,61 @@ func NewClient(opts ClientOptions) (*Client, error) {
 	return &Client{opts, lp, bigquery}, nil
 }
 
-func (c *Client) QuerySummary(ctx context.Context, userID string, creatorID string, spec QuerySpec) (*UsageSummaryRow, error) {
-	summary, err := c.bigquery.QueryUsageSummary(ctx, userID, creatorID, spec)
+func (c *Client) QuerySummary(ctx context.Context, userID string, spec QuerySpec) ([]Metric, error) {
+	summary, err := c.bigquery.QueryUsageSummary(ctx, userID, spec)
+	if err != nil {
+		return nil, err
+	}
+
+	metrics := usageSummaryToMetrics(summary, spec)
+	return metrics, nil
+}
+
+func usageSummaryToMetrics(rows []UsageSummaryRow, spec QuerySpec) []Metric {
+	metrics := make([]Metric, len(rows))
+	for i, row := range rows {
+		m := Metric{
+			UserID:            row.UserID,
+			CreatorID:         toStringPtr(row.CreatorID, spec.hasBreakdownBy("creatorId")),
+			DeliveryUsageMins: toFloat64Ptr(row.DeliveryUsageMins, true),
+			TotalUsageMins:    toFloat64Ptr(row.TotalUsageMins, true),
+			StorageUsageMins:  toFloat64Ptr(row.StorageUsageMins, true),
+		}
+
+		if !row.TimeInterval.IsZero() {
+			timestamp := row.TimeInterval.UnixMilli()
+			m.TimeInterval = &timestamp
+		}
+
+		metrics[i] = m
+	}
+	return metrics
+}
+
+func toFloat64Ptr(bqFloat bigquery.NullFloat64, asked bool) data.Nullable[float64] {
+	return data.ToNullable(bqFloat.Float64, bqFloat.Valid, asked)
+}
+
+func toStringPtr(bqStr bigquery.NullString, asked bool) data.Nullable[string] {
+	return data.ToNullable(bqStr.StringVal, bqStr.Valid, asked)
+}
+
+func (q *QuerySpec) hasBreakdownBy(e string) bool {
+	// callers always set `e` as a string literal so we can panic if it's not valid
+	if usageBreakdownFields[e] == "" {
+		panic(fmt.Sprintf("unknown breakdown field %q", e))
+	}
+
+	for _, a := range q.BreakdownBy {
+		if strings.EqualFold(a, e) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Client) QuerySummaryWithTimestep(ctx context.Context, userID string, spec QuerySpec) ([]UsageSummaryRow, error) {
+	summary, err := c.bigquery.QueryUsageSummaryWithTimestep(ctx, userID, spec)
 	if err != nil {
 		return nil, err
 	}
@@ -39,16 +108,7 @@ func (c *Client) QuerySummary(ctx context.Context, userID string, creatorID stri
 	return summary, nil
 }
 
-func (c *Client) QuerySummaryWithTimestep(ctx context.Context, userID string, creatorID string, spec QuerySpec) (*[]UsageSummaryRow, error) {
-	summary, err := c.bigquery.QueryUsageSummaryWithTimestep(ctx, userID, creatorID, spec)
-	if err != nil {
-		return nil, err
-	}
-
-	return summary, nil
-}
-
-func (c *Client) QueryTotalSummary(ctx context.Context, spec FromToQuerySpec) (*[]TotalUsageSummaryRow, error) {
+func (c *Client) QueryTotalSummary(ctx context.Context, spec FromToQuerySpec) ([]TotalUsageSummaryRow, error) {
 	summary, err := c.bigquery.QueryTotalUsageSummary(ctx, spec)
 	if err != nil {
 		return nil, err
@@ -57,7 +117,7 @@ func (c *Client) QueryTotalSummary(ctx context.Context, spec FromToQuerySpec) (*
 	return summary, nil
 }
 
-func (c *Client) QueryActiveUsageSummary(ctx context.Context, spec FromToQuerySpec) (*[]ActiveUsersSummaryRow, error) {
+func (c *Client) QueryActiveUsageSummary(ctx context.Context, spec FromToQuerySpec) ([]ActiveUsersSummaryRow, error) {
 	summary, err := c.bigquery.QueryActiveUsersUsageSummary(ctx, spec)
 	if err != nil {
 		return nil, err

--- a/usage/client.go
+++ b/usage/client.go
@@ -46,8 +46,8 @@ func NewClient(opts ClientOptions) (*Client, error) {
 	return &Client{opts, lp, bigquery}, nil
 }
 
-func (c *Client) QuerySummary(ctx context.Context, userID string, spec QuerySpec) ([]Metric, error) {
-	summary, err := c.bigquery.QueryUsageSummary(ctx, userID, spec)
+func (c *Client) QuerySummary(ctx context.Context, spec QuerySpec) ([]Metric, error) {
+	summary, err := c.bigquery.QueryUsageSummary(ctx, spec)
 	if err != nil {
 		return nil, err
 	}
@@ -99,8 +99,8 @@ func (q *QuerySpec) hasBreakdownBy(e string) bool {
 	return false
 }
 
-func (c *Client) QuerySummaryWithTimestep(ctx context.Context, userID string, spec QuerySpec) ([]Metric, error) {
-	summary, err := c.bigquery.QueryUsageSummaryWithTimestep(ctx, userID, spec)
+func (c *Client) QuerySummaryWithTimestep(ctx context.Context, spec QuerySpec) ([]Metric, error) {
+	summary, err := c.bigquery.QueryUsageSummaryWithTimestep(ctx, spec)
 	if err != nil {
 		return nil, err
 	}

--- a/usage/client.go
+++ b/usage/client.go
@@ -99,13 +99,14 @@ func (q *QuerySpec) hasBreakdownBy(e string) bool {
 	return false
 }
 
-func (c *Client) QuerySummaryWithTimestep(ctx context.Context, userID string, spec QuerySpec) ([]UsageSummaryRow, error) {
+func (c *Client) QuerySummaryWithTimestep(ctx context.Context, userID string, spec QuerySpec) ([]Metric, error) {
 	summary, err := c.bigquery.QueryUsageSummaryWithTimestep(ctx, userID, spec)
 	if err != nil {
 		return nil, err
 	}
 
-	return summary, nil
+	metrics := usageSummaryToMetrics(summary, spec)
+	return metrics, nil
 }
 
 func (c *Client) QueryTotalSummary(ctx context.Context, spec FromToQuerySpec) ([]TotalUsageSummaryRow, error) {

--- a/usage/client.go
+++ b/usage/client.go
@@ -3,7 +3,6 @@ package usage
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"cloud.google.com/go/bigquery"
 	livepeer "github.com/livepeer/go-api-client"
@@ -79,24 +78,6 @@ func toFloat64Ptr(bqFloat bigquery.NullFloat64, asked bool) data.Nullable[float6
 
 func toStringPtr(bqStr bigquery.NullString, asked bool) data.Nullable[string] {
 	return data.ToNullable(bqStr.StringVal, bqStr.Valid, asked)
-}
-
-func (q *QuerySpec) HasAnyBreakdown() bool {
-	return len(q.BreakdownBy) > 0 || q.TimeStep != ""
-}
-
-func (q *QuerySpec) hasBreakdownBy(e string) bool {
-	// callers always set `e` as a string literal so we can panic if it's not valid
-	if usageBreakdownFields[e] == "" {
-		panic(fmt.Sprintf("unknown breakdown field %q", e))
-	}
-
-	for _, a := range q.BreakdownBy {
-		if strings.EqualFold(a, e) {
-			return true
-		}
-	}
-	return false
 }
 
 func (c *Client) QuerySummaryWithBreakdown(ctx context.Context, spec QuerySpec) ([]Metric, error) {

--- a/usage/query_spec.go
+++ b/usage/query_spec.go
@@ -10,11 +10,6 @@ type FromToQuerySpec struct {
 	From, To *time.Time
 }
 
-var allowedTimeSteps = map[string]bool{
-	"hour": true,
-	"day":  true,
-}
-
 type QueryFilter struct {
 	CreatorID string
 	UserID    string
@@ -25,6 +20,11 @@ type QuerySpec struct {
 	From, To    *time.Time
 	Filter      QueryFilter
 	BreakdownBy []string
+}
+
+var allowedTimeSteps = map[string]bool{
+	"hour": true,
+	"day":  true,
 }
 
 var usageBreakdownFields = map[string]string{

--- a/usage/query_spec.go
+++ b/usage/query_spec.go
@@ -1,0 +1,50 @@
+package usage
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type FromToQuerySpec struct {
+	From, To *time.Time
+}
+
+var allowedTimeSteps = map[string]bool{
+	"hour": true,
+	"day":  true,
+}
+
+type QueryFilter struct {
+	CreatorID string
+	UserID    string
+}
+
+type QuerySpec struct {
+	TimeStep    string
+	From, To    *time.Time
+	Filter      QueryFilter
+	BreakdownBy []string
+}
+
+var usageBreakdownFields = map[string]string{
+	"creatorId": "creator_id",
+}
+
+func (q *QuerySpec) HasAnyBreakdown() bool {
+	return len(q.BreakdownBy) > 0 || q.TimeStep != ""
+}
+
+func (q *QuerySpec) hasBreakdownBy(e string) bool {
+	// callers always set `e` as a string literal so we can panic if it's not valid
+	if usageBreakdownFields[e] == "" {
+		panic(fmt.Sprintf("unknown breakdown field %q", e))
+	}
+
+	for _, a := range q.BreakdownBy {
+		if strings.EqualFold(a, e) {
+			return true
+		}
+	}
+	return false
+}

--- a/views/bigquery.go
+++ b/views/bigquery.go
@@ -8,7 +8,6 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"github.com/Masterminds/squirrel"
-	"github.com/golang/glog"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
@@ -279,7 +278,6 @@ func doBigQuery[RowT any](bq *bigqueryHandler, ctx context.Context, sql string, 
 	query := bq.client.Query(sql)
 	query.Parameters = toBigQueryParameters(args)
 	query.MaxBytesBilled = bq.opts.MaxBytesBilledPerBigQuery
-	glog.V(10).Infof("Running query. sql=%q args=%s", sql, args)
 
 	it, err := query.Read(ctx)
 	if err != nil {
@@ -287,7 +285,6 @@ func doBigQuery[RowT any](bq *bigqueryHandler, ctx context.Context, sql string, 
 	}
 
 	typed, err := toTypedValues[RowT](it)
-	glog.V(10).Infof("typed: %s", typed)
 
 	return typed, err
 }
@@ -311,11 +308,9 @@ func toTypedValues[RowT any](it *bigquery.RowIterator) ([]RowT, error) {
 		} else if err != nil {
 			return nil, fmt.Errorf("error reading query result: %w", err)
 		}
-		glog.V(10).Infof("%s", values)
 
 		values = append(values, row)
 	}
-	glog.V(10).Infof("values: %s %d", values[0], len(values))
 
 	return values, nil
 }

--- a/views/bigquery.go
+++ b/views/bigquery.go
@@ -284,9 +284,7 @@ func doBigQuery[RowT any](bq *bigqueryHandler, ctx context.Context, sql string, 
 		return nil, fmt.Errorf("error running query: %w", err)
 	}
 
-	typed, err := toTypedValues[RowT](it)
-
-	return typed, err
+	return toTypedValues[RowT](it)
 }
 
 func toBigQueryParameters(args []interface{}) []bigquery.QueryParameter {

--- a/views/bigquery.go
+++ b/views/bigquery.go
@@ -286,7 +286,10 @@ func doBigQuery[RowT any](bq *bigqueryHandler, ctx context.Context, sql string, 
 		return nil, fmt.Errorf("error running query: %w", err)
 	}
 
-	return toTypedValues[RowT](it)
+	typed, err := toTypedValues[RowT](it)
+	glog.V(10).Infof("typed: %s", typed)
+
+	return typed, err
 }
 
 func toBigQueryParameters(args []interface{}) []bigquery.QueryParameter {
@@ -308,8 +311,11 @@ func toTypedValues[RowT any](it *bigquery.RowIterator) ([]RowT, error) {
 		} else if err != nil {
 			return nil, fmt.Errorf("error reading query result: %w", err)
 		}
+		glog.V(10).Infof("%s", values)
 
 		values = append(values, row)
 	}
+	glog.V(10).Infof("values: %s %d", values[0], len(values))
+
 	return values, nil
 }

--- a/views/bigquery.go
+++ b/views/bigquery.go
@@ -14,46 +14,6 @@ import (
 
 const maxBigQueryResultRows = 10000
 
-type QueryFilter struct {
-	PlaybackID string
-	CreatorID  string
-	UserID     string
-}
-
-type QuerySpec struct {
-	From, To    *time.Time
-	TimeStep    string
-	Filter      QueryFilter
-	BreakdownBy []string
-	Detailed    bool
-}
-
-var viewershipBreakdownFields = map[string]string{
-	"playbackId":    "playback_id",
-	"dStorageUrl":   "d_storage_url",
-	"deviceType":    "device_type",
-	"device":        "device",
-	"cpu":           "cpu",
-	"os":            "os",
-	"browser":       "browser",
-	"browserEngine": "browser_engine",
-	"continent":     "playback_continent_name",
-	"country":       "playback_country_name",
-	"subdivision":   "playback_subdivision_name",
-	"timezone":      "playback_timezone",
-	"geohash":       "playback_geo_hash",
-	"viewerId":      "viewer_id",
-	"creatorId":     "creator_id",
-}
-
-var allowedTimeSteps = map[string]bool{
-	"hour":  true,
-	"day":   true,
-	"week":  true,
-	"month": true,
-	"year":  true,
-}
-
 type ViewershipEventRow struct {
 	TimeInterval time.Time `bigquery:"time_interval"`
 

--- a/views/client.go
+++ b/views/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"cloud.google.com/go/bigquery"
 	livepeer "github.com/livepeer/go-api-client"
@@ -211,18 +210,4 @@ func toFloat64Ptr(bqFloat bigquery.NullFloat64, asked bool) data.Nullable[float6
 
 func toStringPtr(bqStr bigquery.NullString, asked bool) data.Nullable[string] {
 	return data.ToNullable(bqStr.StringVal, bqStr.Valid, asked)
-}
-
-func (q *QuerySpec) hasBreakdownBy(e string) bool {
-	// callers always set `e` as a string literal so we can panic if it's not valid
-	if viewershipBreakdownFields[e] == "" {
-		panic(fmt.Sprintf("unknown breakdown field %q", e))
-	}
-
-	for _, a := range q.BreakdownBy {
-		if strings.EqualFold(a, e) {
-			return true
-		}
-	}
-	return false
 }

--- a/views/query_spec.go
+++ b/views/query_spec.go
@@ -1,0 +1,61 @@
+package views
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type QueryFilter struct {
+	PlaybackID string
+	CreatorID  string
+	UserID     string
+}
+
+type QuerySpec struct {
+	From, To    *time.Time
+	TimeStep    string
+	Filter      QueryFilter
+	BreakdownBy []string
+	Detailed    bool
+}
+
+var viewershipBreakdownFields = map[string]string{
+	"playbackId":    "playback_id",
+	"dStorageUrl":   "d_storage_url",
+	"deviceType":    "device_type",
+	"device":        "device",
+	"cpu":           "cpu",
+	"os":            "os",
+	"browser":       "browser",
+	"browserEngine": "browser_engine",
+	"continent":     "playback_continent_name",
+	"country":       "playback_country_name",
+	"subdivision":   "playback_subdivision_name",
+	"timezone":      "playback_timezone",
+	"geohash":       "playback_geo_hash",
+	"viewerId":      "viewer_id",
+	"creatorId":     "creator_id",
+}
+
+var allowedTimeSteps = map[string]bool{
+	"hour":  true,
+	"day":   true,
+	"week":  true,
+	"month": true,
+	"year":  true,
+}
+
+func (q *QuerySpec) hasBreakdownBy(e string) bool {
+	// callers always set `e` as a string literal so we can panic if it's not valid
+	if viewershipBreakdownFields[e] == "" {
+		panic(fmt.Sprintf("unknown breakdown field %q", e))
+	}
+
+	for _, a := range q.BreakdownBy {
+		if strings.EqualFold(a, e) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
 * added the ability to breakdown by creator id to the usage metrics api
 * Added nullable types to remove unused grouping fields (time interval, creator id). 
 * Fixed UsageWithTimestamp that did not return the time interval
 * increased default query quota that consistently failed

Test Queries
I used Trovo's api key
```
import requests
url = 'http://127.0.0.1:8080/data/usage/query'
headers={'Authorization': 'Bearer ' + key}

# return all usage rolled up to the userid
params = {
    'from': int(time.mktime((datetime.utcnow() - timedelta(days=1)).timetuple()))*1000,
    'to': int(time.mktime(datetime.utcnow().timetuple()))*1000,
}

# return all usage rolled up to the userid and creator id
params = {
    'from': int(time.mktime((datetime.utcnow() - timedelta(days=1)).timetuple()))*1000,
    'to': int(time.mktime(datetime.utcnow().timetuple()))*1000,
    'breakdownBy[]':['creatorId' ], 
}

# returns all usage for just user broken down by hour
params = {
    'from': int(time.mktime((datetime.utcnow() - timedelta(days=1)).timetuple()))*1000,
    'to': int(time.mktime(datetime.utcnow().timetuple()))*1000,
    'timeStep':'hour',
}

# returns all usage for both user and creator id broken down by hour
params = {
    'from': int(time.mktime((datetime.utcnow() - timedelta(days=1)).timetuple()))*1000,
    'to': int(time.mktime(datetime.utcnow().timetuple()))*1000,
    'breakdownBy[]':['creatorId' ], 
    'timeStep':'hour',
}

# return all usage for just a specific creator
params = {
    'from': int(time.mktime((datetime.utcnow() - timedelta(days=1)).timetuple()))*1000,
    'to': int(time.mktime(datetime.utcnow().timetuple()))*1000,
    'creatorId':'67281_11878_11878'
}

# return all usage for just a specific creator broken down by hour and also throwing in a wrinkle where we try and group by the creator too
params = {
    'from': int(time.mktime((datetime.utcnow() - timedelta(days=1)).timetuple()))*1000,
    'to': int(time.mktime(datetime.utcnow().timetuple()))*1000,
    'breakdownBy[]':['creatorId' ], 
    'timeStep':'hour',
    'creatorId':'67281_11878_11878'
}

for param in params:
    print(param)
    r = requests.get(url, headers=headers, params=param)
    # pprint(r.json())
    if r.status_code != 200:
        print(r.text)
        break
    time.sleep(2)

```