### PR TITLE
Split Realtime Viewership API into Now and Time Series APIs

### DIFF
--- a/api/handler.go
+++ b/api/handler.go
@@ -149,7 +149,7 @@ func (h *apiHandler) viewershipHandler() chi.Router {
 	// realtime viewership
 	h.withMetrics(router, "query_realtime_viewership").
 		MethodFunc("GET", `/now`, h.queryRealtimeViewership())
-	h.withMetrics(router, "query_realtime_viewership").
+	h.withMetrics(router, "query_timeseries_realtime_viewership").
 		MethodFunc("GET", `/internal/timeSeries`, h.queryTimeSeriesRealtimeViewership())
 
 	return router

--- a/api/handler.go
+++ b/api/handler.go
@@ -411,7 +411,7 @@ func (h *apiHandler) queryTimeSeriesRealtimeViewership() http.HandlerFunc {
 			respondError(rw, httpErrorCode, errs...)
 			return
 		}
-		metrics, err := h.views.QueryRealtimeEvents(r.Context(), querySpec)
+		metrics, err := h.views.QueryTimeSeriesRealtimeEvents(r.Context(), querySpec)
 		if err != nil {
 			respondError(rw, http.StatusInternalServerError, err)
 			return

--- a/views/clickhouse.go
+++ b/views/clickhouse.go
@@ -87,7 +87,8 @@ func (c *ClickhouseClient) QueryTimeSeriesRealtimeViewsEvents(ctx context.Contex
 
 func buildRealtimeViewsEventsQuery(spec QuerySpec) (string, []interface{}, error) {
 	query := squirrel.Select(
-		"count(distinct session_id) as view_count").
+		"count(distinct session_id) as view_count",
+		"sum(if(errors > 0, 1, 0)) / count(distinct session_id) as error_rate")
 		From("viewership_events").
 		Where("user_id = ?", spec.Filter.UserID).
 		Where("server_timestamp > (toUnixTimestamp(now() - 30)) * 1000").

--- a/views/clickhouse.go
+++ b/views/clickhouse.go
@@ -28,6 +28,7 @@ type RealtimeViewershipRow struct {
 
 type Clickhouse interface {
 	QueryRealtimeViewsEvents(ctx context.Context, spec QuerySpec) ([]RealtimeViewershipRow, error)
+	QueryTimeSeriesRealtimeViewsEvents(ctx context.Context, spec QuerySpec) ([]RealtimeViewershipRow, error)
 }
 
 type ClickhouseOptions struct {
@@ -74,14 +75,56 @@ func (c *ClickhouseClient) QueryRealtimeViewsEvents(ctx context.Context, spec Qu
 	return res, nil
 }
 
-func buildRealtimeViewsEventsQuery(spec QuerySpec) (string, []interface{}, error) {
-	var query squirrel.SelectBuilder
-	if spec.From == nil && spec.To == nil {
-		query = currentEventsQuery(spec)
-	} else {
-		query = timeRangeEventsQuery(spec)
+func (c *ClickhouseClient) QueryTimeSeriesRealtimeViewsEvents(ctx context.Context, spec QuerySpec) ([]RealtimeViewershipRow, error) {
+	sql, args, err := buildTimeSeriesRealtimeViewsEventsQuery(spec)
+	if err != nil {
+		return nil, fmt.Errorf("error building viewership events query: %w", err)
 	}
+	var res []RealtimeViewershipRow
+	err = c.conn.Select(ctx, &res, sql, args...)
+	if err != nil {
+		return nil, err
+	} else if len(res) > maxClickhouseResultRows {
+		return nil, fmt.Errorf("query must return less than %d datapoints. consider decreasing your timeframe", maxClickhouseResultRows)
+	}
+	res = replaceNaNBufferRatio(res)
 
+	return res, nil
+}
+
+func buildRealtimeViewsEventsQuery(spec QuerySpec) (string, []interface{}, error) {
+	query := squirrel.Select(
+		"count(distinct session_id) as view_count").
+		From("viewership_events").
+		Where("user_id = ?", spec.Filter.UserID).
+		Where("server_timestamp > (toUnixTimestamp(now() - 30)) * 1000").
+		Limit(maxClickhouseResultRows + 1)
+	return toSqlWithFiltersAndBreakdown(query, spec)
+}
+
+func buildTimeSeriesRealtimeViewsEventsQuery(spec QuerySpec) (string, []interface{}, error) {
+	query := squirrel.Select(
+		"timestamp_ts",
+		"count(distinct session_id) as view_count",
+		"sum(buffer_ms) / (sum(playtime_ms) + sum(buffer_ms)) as buffer_ratio",
+		"sum(if(errors > 0, 1, 0)) / count(*) as error_rate").
+		From("viewership_sessions_by_minute").
+		Where("user_id = ?", spec.Filter.UserID).
+		GroupBy("timestamp_ts").
+		OrderBy("timestamp_ts desc").
+		Limit(maxClickhouseResultRows + 1)
+	if spec.From != nil {
+		// timestamp_ts is DateTime, but it's automatically converted to seconds
+		query = query.Where("timestamp_ts >= ?", spec.From.UnixMilli()/1000)
+	}
+	if spec.To != nil {
+		// timestamp_ts is DateTime, but it's automatically converted to seconds
+		query = query.Where("timestamp_ts < ?", spec.To.UnixMilli()/1000)
+	}
+	return toSqlWithFiltersAndBreakdown(query, spec)
+}
+
+func toSqlWithFiltersAndBreakdown(query squirrel.SelectBuilder, spec QuerySpec) (string, []interface{}, error) {
 	query = withPlaybackIdFilter(query, spec.Filter.PlaybackID)
 	if creatorId := spec.Filter.CreatorID; creatorId != "" {
 		query = query.Where("creator_id = ?", creatorId)
@@ -106,40 +149,6 @@ func buildRealtimeViewsEventsQuery(spec QuerySpec) (string, []interface{}, error
 	}
 
 	return sql, args, nil
-}
-
-// currentEventsQuery uses an unoptimized raw playback logs to favor latency over query speed.
-func currentEventsQuery(spec QuerySpec) squirrel.SelectBuilder {
-	return squirrel.Select(
-		"count(distinct session_id) as view_count").
-		From("viewership_events").
-		Where("user_id = ?", spec.Filter.UserID).
-		Where("server_timestamp > (toUnixTimestamp(now() - 30)) * 1000").
-		Limit(maxClickhouseResultRows + 1)
-}
-
-// timeRangeEventsQuery uses an optimized materialized view "per minute" to favor query time against the latency.
-func timeRangeEventsQuery(spec QuerySpec) squirrel.SelectBuilder {
-	query := squirrel.Select(
-		"timestamp_ts",
-		"count(distinct session_id) as view_count",
-		"sum(buffer_ms) / (sum(playtime_ms) + sum(buffer_ms)) as buffer_ratio",
-		"sum(if(errors > 0, 1, 0)) / count(*) as error_rate").
-		From("viewership_sessions_by_minute").
-		Where("user_id = ?", spec.Filter.UserID).
-		GroupBy("timestamp_ts").
-		OrderBy("timestamp_ts desc").
-		Limit(maxClickhouseResultRows + 1)
-
-	if spec.From != nil {
-		// timestamp_ts is DateTime, but it's automatically converted to seconds
-		query = query.Where("timestamp_ts >= ?", spec.From.UnixMilli()/1000)
-	}
-	if spec.To != nil {
-		// timestamp_ts is DateTime, but it's automatically converted to seconds
-		query = query.Where("timestamp_ts < ?", spec.To.UnixMilli()/1000)
-	}
-	return query
 }
 
 func replaceNaNBufferRatio(rows []RealtimeViewershipRow) []RealtimeViewershipRow {

--- a/views/clickhouse.go
+++ b/views/clickhouse.go
@@ -61,24 +61,17 @@ func NewClickhouseConn(opts ClickhouseOptions) (*ClickhouseClient, error) {
 func (c *ClickhouseClient) QueryRealtimeViewsEvents(ctx context.Context, spec QuerySpec) ([]RealtimeViewershipRow, error) {
 	sql, args, err := buildRealtimeViewsEventsQuery(spec)
 	if err != nil {
-		return nil, fmt.Errorf("error building viewership events query: %w", err)
+		return nil, fmt.Errorf("error building realtime viewership events query: %w", err)
 	}
 	var res []RealtimeViewershipRow
 	err = c.conn.Select(ctx, &res, sql, args...)
-	if err != nil {
-		return nil, err
-	} else if len(res) > maxClickhouseResultRows {
-		return nil, fmt.Errorf("query must return less than %d datapoints. consider decreasing your timeframe", maxClickhouseResultRows)
-	}
-	res = replaceNaNBufferRatio(res)
-
-	return res, nil
+	return res, err
 }
 
 func (c *ClickhouseClient) QueryTimeSeriesRealtimeViewsEvents(ctx context.Context, spec QuerySpec) ([]RealtimeViewershipRow, error) {
 	sql, args, err := buildTimeSeriesRealtimeViewsEventsQuery(spec)
 	if err != nil {
-		return nil, fmt.Errorf("error building viewership events query: %w", err)
+		return nil, fmt.Errorf("error building time series realtime viewership events query: %w", err)
 	}
 	var res []RealtimeViewershipRow
 	err = c.conn.Select(ctx, &res, sql, args...)

--- a/views/clickhouse.go
+++ b/views/clickhouse.go
@@ -88,7 +88,7 @@ func (c *ClickhouseClient) QueryTimeSeriesRealtimeViewsEvents(ctx context.Contex
 func buildRealtimeViewsEventsQuery(spec QuerySpec) (string, []interface{}, error) {
 	query := squirrel.Select(
 		"count(distinct session_id) as view_count",
-		"sum(if(errors > 0, 1, 0)) / count(distinct session_id) as error_rate")
+		"sum(if(errors > 0, 1, 0)) / count(distinct session_id) as error_rate").
 		From("viewership_events").
 		Where("user_id = ?", spec.Filter.UserID).
 		Where("server_timestamp > (toUnixTimestamp(now() - 30)) * 1000").

--- a/views/client.go
+++ b/views/client.go
@@ -157,6 +157,15 @@ func (c *Client) QueryRealtimeEvents(ctx context.Context, spec QuerySpec) ([]Met
 	return metrics, nil
 }
 
+func (c *Client) QueryTimeSeriesRealtimeEvents(ctx context.Context, spec QuerySpec) ([]Metric, error) {
+	rows, err := c.clickhouse.QueryTimeSeriesRealtimeViewsEvents(ctx, spec)
+	if err != nil {
+		return nil, err
+	}
+	metrics := realtimeViewershipEventsToMetrics(rows, spec)
+	return metrics, nil
+}
+
 func (c *Client) ResolvePlaybackId(spec QuerySpec, assetID, streamID string) (QuerySpec, error) {
 	res := spec
 	var err error

--- a/views/client.go
+++ b/views/client.go
@@ -238,7 +238,7 @@ func realtimeViewershipEventsToMetrics(rows []RealtimeViewershipRow, spec QueryS
 		m := Metric{
 			ViewCount:     int64(row.ViewCount),
 			RebufferRatio: toFloat64Ptr(row.BufferRatio, isTimeRange),
-			ErrorRate:     toFloat64Ptr(row.ErrorRate, isTimeRange),
+			ErrorRate:     data.WrapNullable(row.ErrorRate),
 			PlaybackID:    toStringPtr(row.PlaybackID, spec.hasBreakdownBy("playbackId")),
 			DeviceType:    toStringPtr(row.DeviceType, spec.hasBreakdownBy("deviceType")),
 			Browser:       toStringPtr(row.Browser, spec.hasBreakdownBy("browser")),

--- a/views/client_test.go
+++ b/views/client_test.go
@@ -36,12 +36,14 @@ func TestQueryRealtimeEvents(t *testing.T) {
 			rows: []RealtimeViewershipRow{
 				{
 					ViewCount: 2,
+					ErrorRate: 0.2,
 				},
 			},
 			expJson: `
 				[
 					{
-						"viewCount":2
+						"viewCount": 2,
+						"errorRate": 0.2
 					}
 				]
 			`,
@@ -54,6 +56,7 @@ func TestQueryRealtimeEvents(t *testing.T) {
 			rows: []RealtimeViewershipRow{
 				{
 					ViewCount:   2,
+					ErrorRate:   0.3,
 					PlaybackID:  "playbackid-1",
 					CountryName: "Poland",
 				},
@@ -62,6 +65,7 @@ func TestQueryRealtimeEvents(t *testing.T) {
 				[
 					{
 						"viewCount": 2,
+						"errorRate": 0.3,
 						"playbackId": "playbackid-1",
 						"country": "Poland"
 					}

--- a/views/client_test.go
+++ b/views/client_test.go
@@ -18,6 +18,10 @@ func (m MockClickhouseClient) QueryRealtimeViewsEvents(ctx context.Context, spec
 	return m.rows, nil
 }
 
+func (m MockClickhouseClient) QueryTimeSeriesRealtimeViewsEvents(ctx context.Context, spec QuerySpec) ([]RealtimeViewershipRow, error) {
+	return m.rows, nil
+}
+
 func TestQueryRealtimeEvents(t *testing.T) {
 	require := require.New(t)
 
@@ -64,6 +68,35 @@ func TestQueryRealtimeEvents(t *testing.T) {
 				]
 			`,
 		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// given
+			mockClickhouse := MockClickhouseClient{rows: tt.rows}
+			client := Client{clickhouse: &mockClickhouse}
+
+			// when
+			res, err := client.QueryRealtimeEvents(context.Background(), tt.spec)
+
+			// then
+			require.NoError(err)
+			jsonRes, err := json.Marshal(res)
+			require.NoError(err)
+			require.JSONEq(tt.expJson, string(jsonRes))
+		})
+	}
+}
+
+func TestQueryTimeSeriesRealtimeEvents(t *testing.T) {
+	require := require.New(t)
+
+	tests := []struct {
+		name    string
+		spec    QuerySpec
+		rows    []RealtimeViewershipRow
+		expJson string
+	}{
 		{
 			name: "time range with no breakdown",
 			spec: QuerySpec{From: &timestamp},
@@ -124,7 +157,7 @@ func TestQueryRealtimeEvents(t *testing.T) {
 			client := Client{clickhouse: &mockClickhouse}
 
 			// when
-			res, err := client.QueryRealtimeEvents(context.Background(), tt.spec)
+			res, err := client.QueryTimeSeriesRealtimeEvents(context.Background(), tt.spec)
 
 			// then
 			require.NoError(err)


### PR DESCRIPTION
As discussed in [Discord](https://discord.com/channels/423160867534929930/1217483431114706974/1217483433303867422), we split `/data/views/active` API into two separate APIs:
- `/data/views/now`
- `/data/views/internal/timeSeries`

fix https://linear.app/livepeer/issue/ENG-1799/revisit-viewsactive-api