### PR TITLE
Improve user-facing error message

### DIFF
--- a/api/authorization.go
+++ b/api/authorization.go
@@ -79,6 +79,12 @@ func authorization(authUrl string) middleware {
 			return
 		}
 
+		// It not found, we just pass NotFound to the client
+		if authRes.StatusCode == http.StatusNotFound {
+			rw.WriteHeader(http.StatusNotFound)
+			return
+		}
+
 		if authRes.StatusCode != http.StatusOK && authRes.StatusCode != http.StatusNoContent {
 			if contentType := authRes.Header.Get("Content-Type"); contentType != "" {
 				rw.Header().Set("Content-Type", contentType)


### PR DESCRIPTION
Currently, when a user passes a not-existing stream, asset, or playback, we print this weird message to the user:
```json
{
    "errors": [
        "failed to find object from x-livepeer-playback-id header"
    ]
}
```

I don't think we should print it, it's meaningless to users. They don't even pass this `x-livepeer-playback-id` header.

fix https://linear.app/livepeer/issue/ENG-2094/fix-filtering-by-non-existing-playbackid