### PR TITLE
Support for adding additional capacity filters in config

### DIFF
--- a/ai/client.go
+++ b/ai/client.go
@@ -9,18 +9,19 @@ import (
 )
 
 type Client struct {
-	prom *prometheus.Prometheus
+	prom                 *prometheus.Prometheus
+	capacityQueryFilters string
 }
 
-func NewClient(promConfig promClient.Config) (*Client, error) {
+func NewClient(promConfig promClient.Config, capacityQueryFilters string) (*Client, error) {
 	prom, err := prometheus.NewPrometheus(promConfig)
 	if err != nil {
 		return nil, fmt.Errorf("error creating prometheus client: %w", err)
 	}
 
-	return &Client{prom}, nil
+	return &Client{prom, capacityQueryFilters}, nil
 }
 
 func (c *Client) QueryAICapacity(ctx context.Context, regions, nodeID, regionsExclude string) (prometheus.AICapacity, error) {
-	return c.prom.QueryAICapacity(ctx, regions, nodeID, regionsExclude)
+	return c.prom.QueryAICapacity(ctx, regions, nodeID, regionsExclude, c.capacityQueryFilters)
 }

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -50,6 +50,8 @@ type cliFlags struct {
 
 	viewsOpts views.ClientOptions
 	usageOpts usage.ClientOptions
+
+	aiCapacityQueryFilters string
 }
 
 func parseFlags(version string) cliFlags {
@@ -103,6 +105,8 @@ func parseFlags(version string) cliFlags {
 	fs.StringVar(&cli.viewsOpts.ClickhouseOptions.User, "clickhouse-user", "", "Clickhouse User")
 	fs.StringVar(&cli.viewsOpts.ClickhouseOptions.Password, "clickhouse-password", "", "Clickhouse Password")
 
+	fs.StringVar(&cli.aiCapacityQueryFilters, "ai-capacity-query-filters", "", "Additional prometheus filters to use for AI capacity query")
+
 	flag.Set("logtostderr", "true")
 	glogVFlag := flag.Lookup("v")
 	verbosity := fs.Int("v", 0, "Log verbosity {0-10}")
@@ -155,7 +159,7 @@ func Run(build BuildFlags) {
 
 	views, usage := provisionDataAnalytics(cli)
 
-	ai, err := ai.NewClient(cli.viewsOpts.Prometheus)
+	ai, err := ai.NewClient(cli.viewsOpts.Prometheus, cli.aiCapacityQueryFilters)
 	if err != nil {
 		glog.Fatalf("Error creating ai client. err=%q", err)
 	}

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -79,7 +79,7 @@ type AICapacity struct {
 	IdleContainers  int64 `json:"idleContainers"`
 }
 
-func (c *Prometheus) QueryAICapacity(ctx context.Context, regions, nodeID, regionsExclude string) (AICapacity, error) {
+func (c *Prometheus) QueryAICapacity(ctx context.Context, regions, nodeID, regionsExclude, additionalFilters string) (AICapacity, error) {
 	regionFilter, nodeIDFilter := "", ""
 	if regions != "" {
 		regionFilter = fmt.Sprintf(`, region=~"%s"`, strings.Replace(regions, ",", "|", -1))
@@ -91,7 +91,7 @@ func (c *Prometheus) QueryAICapacity(ctx context.Context, regions, nodeID, regio
 	if regionsExclude != "" {
 		regionsExcludeFilter = fmt.Sprintf(`, region!~"%s"`, strings.Replace(regionsExclude, ",", "|", -1))
 	}
-	filters := fmt.Sprintf(`{job="orchestrator"%s%s%s}`, regionsExcludeFilter, regionFilter, nodeIDFilter)
+	filters := fmt.Sprintf(`{job="orchestrator"%s%s%s%s}`, regionsExcludeFilter, regionFilter, nodeIDFilter, additionalFilters)
 
 	query := fmt.Sprintf(`sum(livepeer_ai_container_idle%s)`, filters)
 


### PR DESCRIPTION
I'll use this to switch between the existing O reported metrics and the new Gateway ones by adding a filter to check for the existence of a tag only reported by the Gateway.